### PR TITLE
ci: add build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a GitHub Actions CI workflow that runs on push to main and PRs:

- **Install** (`npm ci`)
- **Type check** (`tsc --noEmit`)
- **Build** (`tsc`)
- **Test** (`vitest run`)

Matrix: Node.js 22 + 24.