### PR TITLE
fix: replay missed messages on WebSocket reconnect

### DIFF
--- a/src/channels/mattermost/adapter.ts
+++ b/src/channels/mattermost/adapter.ts
@@ -37,6 +37,7 @@ export class MattermostAdapter implements ChannelAdapter {
   private activeChannels = new Map<string, number>(); // channelId → last activity timestamp
   private recentPostIds = new Set<string>();
   private isReplaying = false;
+  private pendingReplay: { sinceTimestamp: number; gapMs: number } | null = null;
   private static readonly MAX_RECENT_POSTS = 500;
   private static readonly MAX_REPLAY_WINDOW_MS = 60_000;
   private static readonly CHANNEL_STALENESS_MS = 3_600_000; // 1 hour
@@ -424,9 +425,10 @@ export class MattermostAdapter implements ChannelAdapter {
       return;
     }
 
-    // Concurrency guard: cancel any previous replay
+    // Concurrency guard: queue latest replay request if one is in progress
     if (this.isReplaying) {
-      log.warn('Replay already in progress — skipping (newer reconnect will subsume)');
+      log.info('Replay in progress — queuing latest reconnect for retry');
+      this.pendingReplay = { sinceTimestamp, gapMs };
       return;
     }
     this.isReplaying = true;
@@ -486,7 +488,7 @@ export class MattermostAdapter implements ChannelAdapter {
           if (!post || post.user_id === this.botId) continue;
           if (post.delete_at > 0) continue;
 
-          this.trackPost(postId, channelId);
+          this.trackPost(postId, channelId, post.create_at);
 
           // Resolve username (cached)
           let username = usernames.get(post.user_id) ?? '';
@@ -541,6 +543,15 @@ export class MattermostAdapter implements ChannelAdapter {
     log.info(`Replay complete: ${replayCount} message(s) replayed across ${channels.length} channel(s)`);
     } finally {
       this.isReplaying = false;
+      // Process queued replay if a newer reconnect occurred during this replay
+      const pending = this.pendingReplay;
+      if (pending) {
+        this.pendingReplay = null;
+        log.info('Processing queued replay from concurrent reconnect');
+        this.replayMissedMessages(pending.sinceTimestamp, pending.gapMs).catch(err =>
+          log.error('Failed to process queued replay:', err)
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Replays messages missed during WebSocket disconnects by fetching posts from the Mattermost REST API on reconnect.

### What it does
- On WS close, records the last known server-side timestamp (`post.create_at`)
- On reconnect, fetches posts since that timestamp for recently active channels
- Deduplicates against a bounded set of recently-seen post IDs
- Dispatches missed messages through existing handlers as if received live

### Safeguards
- **Clock skew immunity**: Uses server-side timestamps instead of client `Date.now()`; falls back to client time with 5s safety buffer
- **Replay window cap**: Skips replay if disconnect lasted >60s (stale messages could cause confusion)
- **Channel staleness filter**: Only replays channels active within the last hour (avoids unbounded API calls)
- **Concurrency guard**: `isReplaying` flag prevents duplicate replays during reconnect storms
- **Post ID dedup**: Bounded at 500 entries with FIFO eviction
- **Error isolation**: Per-channel and per-handler try/catch prevents one failure from blocking others

### Key changes
- `src/channels/mattermost/adapter.ts`: Added close/error/reconnect listeners, `replayMissedMessages()`, `trackPost()`, server timestamp tracking

Fixes #14