### PR TITLE
refactor: adapter factory pattern for platform extensibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,7 @@ async function main(): Promise<void> {
     log.info(`${key} connected`);
 
     // Discover existing DM channels and auto-register any that aren't configured
-    if (adapter.discoverDMChannels) {
+    if (typeof adapter.discoverDMChannels === 'function') {
       const dmChannels = await adapter.discoverDMChannels();
       let registered = 0;
       for (const dm of dmChannels) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export interface ChannelAdapter {
   discoverDMChannels?(): Promise<{ channelId: string; otherUserId: string }[]>;
 }
 
-/** Adapter factory — each platform adapter exports one of these. */
+/** Factory function type for constructing a ChannelAdapter instance for a given platform. */
 export type AdapterFactory = (platformName: string, url: string, token: string) => ChannelAdapter;
 
 // Session state tracked per channel


### PR DESCRIPTION
## Summary
Decouples platform adapters from core via a factory pattern, enabling future multi-platform support without code changes to the bridge.

### What it does
- Adds `AdapterFactory` type and `discoverDMChannels?` optional method to `ChannelAdapter` interface
- Replaces hardcoded `if (platformName === 'mattermost')` with an adapter factory registry
- Replaces `instanceof MattermostAdapter` with optional method check on the interface
- Warns and skips unknown platform names in config

### Key changes
- `src/types.ts`: Added `AdapterFactory` type, `discoverDMChannels?` to `ChannelAdapter`
- `src/index.ts`: Adapter factory registry, generic DM discovery via interface

### Architecture
Future adapters (Slack, Discord, etc.) just add an entry to `adapterFactories`. The `ChannelAdapter` interface is the  no core changes needed.contract 

No behavioral  Mattermost adapter works exactly as before.changes 

Relates to [#24](https://github.com/ChrisRomp/copilot-bridge/issues/24)