### PR TITLE
fix: allow file-only messages without text

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -242,8 +242,8 @@ async function main(): Promise<void> {
       if (isBusy(msg.channelId)) {
         handleMidTurnMessage(msg, sessionManager, platformName, botName)
           .catch(err => {
-            // Expected fallback (slash commands during busy) — debug level
-            const expected = err?.message === 'slash-command-while-busy';
+            // Expected fallbacks — debug level
+            const expected = err?.message === 'slash-command-while-busy' || err?.message === 'file-only-while-busy';
             if (expected) {
               log.debug(`Mid-turn fallback (${err.message}), routing to normal handler`);
             } else {
@@ -891,6 +891,7 @@ async function handleInboundMessage(
   }
 
   // Pending user input
+  // TODO: file-only messages (empty text + attachments) resolve input with empty string and drop files
   if (sessionManager.hasPendingUserInput(msg.channelId)) {
     sessionManager.resolveUserInput(msg.channelId, text);
     return;


### PR DESCRIPTION
## Summary
File-only messages (attachments with no text) were silently dropped by early-exit guards.

### What it does
- Allows messages with attachments but no text to pass through to the Copilot session
- Sends `See attached file(s).` as the prompt when text is empty but attachments exist
- File-only messages during mid-turn are queued (can't steer with no text)
- Guards against all downloads failing: cancels stream with error instead of sending empty prompt

### Key changes
- Mid-turn handler: file-only throws to queued path, empty-text guard updated
- Post-download guard: if both prompt and attachments empty, cancel gracefully

### Known deferred
- File-only message during pending user input resolves input with empty text (edge case, deferred)
