### PR TITLE
fix: context-aware CLI hints in init wizard

### DIFF
--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -16,6 +16,7 @@ import { getConfigPath, getConfigDir } from './lib/config-gen.js';
 import { detectPlatform, getServiceStatus } from './lib/service.js';
 
 async function main() {
+  const isCli = process.env.COPILOT_BRIDGE_CLI === '1';
   console.log();
   heading('🔍 copilot-bridge check');
   dim('Validating your installation...\n');
@@ -38,7 +39,7 @@ async function main() {
     const result: CheckResult = { status: 'fail', label: 'Config file', detail: `not found at ${configPath}` };
     printCheck(result);
     results.push(result);
-    info(process.env.COPILOT_BRIDGE_CLI === '1'
+    info(isCli
       ? 'Run "copilot-bridge init" to create a config file.'
       : 'Run "npm run init" to create a config file.');
     printSummary(results);
@@ -227,7 +228,6 @@ async function main() {
     printCheck(result);
     results.push(result);
   } else {
-    const isCli = process.env.COPILOT_BRIDGE_CLI === '1';
     const platform = detectPlatform();
     const serviceHint = platform === 'macos'
       ? `install with: ${isCli ? 'copilot-bridge install-service' : 'npm run install-service'}`

--- a/scripts/init.ts
+++ b/scripts/init.ts
@@ -16,6 +16,7 @@ import { buildConfig, writeConfig, configExists, getConfigPath, getConfigDir, ty
 import { detectPlatform } from './lib/service.js';
 
 async function main() {
+  const isCli = process.env.COPILOT_BRIDGE_CLI === '1';
   console.log();
   heading('🚀 copilot-bridge setup');
   dim('Interactive wizard to configure copilot-bridge.\n');
@@ -50,7 +51,9 @@ async function main() {
     blank();
     warn(`Existing config found at ${getConfigPath()}`);
     if (!await confirm('Overwrite with a new config?', false)) {
-      info('Run "npm run check" to validate your existing config.');
+      info(isCli
+        ? 'Run "copilot-bridge check" to validate your existing config.'
+        : 'Run "npm run check" to validate your existing config.');
       closePrompts();
       process.exit(0);
     }
@@ -103,7 +106,9 @@ async function main() {
       });
       success(`Added bot "${validation.bot.username}"${isAdmin ? ' (admin)' : ''}`);
     } else {
-      warn('Token validation failed. The token was still added — verify it later with "npm run check".');
+      warn(isCli
+        ? 'Token validation failed. The token was still added — verify it later with "copilot-bridge check".'
+        : 'Token validation failed. The token was still added — verify it later with "npm run check".');
       let name = await askRequired('Bot username (for config)');
       name = name.replace(/^@/, '');
       bots.push({ name, token, admin: false });
@@ -214,14 +219,16 @@ async function main() {
   const osPlatform = detectPlatform();
   if (osPlatform === 'macos') {
     info('To run as a launchd service (auto-start at login):');
-    dim('  npm run install-service\n');
+    dim(isCli ? '  copilot-bridge install-service\n' : '  npm run install-service\n');
   } else if (osPlatform === 'linux') {
     info('To run as a systemd service (auto-start at boot):');
-    dim('  npm run install-service');
+    dim(isCli ? '  copilot-bridge install-service' : '  npm run install-service');
     dim('  (requires sudo — installs to /etc/systemd/system/)\n');
-    dim('  Note: build first with npm run build\n');
+    if (!isCli) dim('  Note: build first with npm run build\n');
   } else {
-    info('Run the bridge manually: npm run dev (development) or npm start (production)');
+    info(isCli
+      ? 'Run the bridge manually: copilot-bridge start'
+      : 'Run the bridge manually: npm run dev (development) or npm start (production)');
   }
 
   // --- Done ---
@@ -233,8 +240,6 @@ async function main() {
   info('DMs: enabled automatically');
   blank();
 
-  // Detect if running via the copilot-bridge CLI (global install)
-  const isCli = process.env.COPILOT_BRIDGE_CLI === '1';
   dim('Next steps:');
   if (isCli) {
     dim('  copilot-bridge check            Validate your setup');

--- a/scripts/install-service.ts
+++ b/scripts/install-service.ts
@@ -21,6 +21,7 @@ import {
 import { execSync } from 'node:child_process';
 
 function main() {
+  const isCli = process.env.COPILOT_BRIDGE_CLI === '1';
   const osPlatform = detectPlatform();
   const bridgePath = process.cwd();
   const homePath = os.homedir();
@@ -35,7 +36,7 @@ function main() {
 
     const distPath = path.join(bridgePath, 'dist', 'index.js');
     if (!fs.existsSync(distPath)) {
-      fail(process.env.COPILOT_BRIDGE_CLI === '1'
+      fail(isCli
         ? 'dist/index.js not found. Package may be corrupted — try reinstalling.'
         : 'dist/index.js not found. Run "npm run build" first.');
       process.exit(1);
@@ -71,7 +72,7 @@ function main() {
 
     const distPath = path.join(bridgePath, 'dist', 'index.js');
     if (!fs.existsSync(distPath)) {
-      fail(process.env.COPILOT_BRIDGE_CLI === '1'
+      fail(isCli
         ? 'dist/index.js not found. Package may be corrupted — try reinstalling.'
         : 'dist/index.js not found. Run "npm run build" first.');
       process.exit(1);
@@ -118,7 +119,7 @@ function main() {
 
   } else {
     fail('Unsupported platform for automatic service install.');
-    info(process.env.COPILOT_BRIDGE_CLI === '1'
+    info(isCli
       ? 'Run the bridge manually: copilot-bridge start'
       : 'Run the bridge manually: npm run dev (development) or npm start (production)');
     process.exit(1);


### PR DESCRIPTION
The init wizard showed `npm run check` even when running via `copilot-bridge init`. Now detects CLI mode and shows the correct commands.

Fixes two remaining instances in init.ts (existing config prompt, token validation failure).