### PR TITLE
build(deps): upgrade Mattermost packages to 11.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "copilot-bridge",
+  "name": "@chrisromp/copilot-bridge",
   "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "copilot-bridge",
+      "name": "@chrisromp/copilot-bridge",
       "version": "0.6.1",
       "dependencies": {
         "@github/copilot-sdk": "^0.1.32",
-        "@mattermost/client": "^10.3.0",
-        "@mattermost/types": "^10.3.0",
+        "@mattermost/client": "^11.4.0",
+        "@mattermost/types": "^11.4.0",
         "better-sqlite3": "^12.6.2",
         "cron": "^4.4.0",
         "cronstrue": "^3.13.0",
@@ -18,11 +18,17 @@
         "tsx": "^4.21.0",
         "ws": "^8.18.0"
       },
+      "bin": {
+        "copilot-bridge": "bin/copilot-bridge.js"
+      },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
         "@types/ws": "^8.5.14",
         "typescript": "^5.7.3",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -576,12 +582,12 @@
       "license": "MIT"
     },
     "node_modules/@mattermost/client": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@mattermost/client/-/client-10.12.0.tgz",
-      "integrity": "sha512-O+PRXXoR/8VXsMuE6ShsWAt/iuvCdyFhXtsJxYCeBrfg99L22lvTaIxE8xZN8lVDIOwJI9jYxFgb8CTGND/l9Q==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@mattermost/client/-/client-11.4.0.tgz",
+      "integrity": "sha512-QzYIpxFRPA+NDCCxk9bPwnFRpgZq8d1KKYXic8AJJiPXjja6IJDOkpDfGgo4b1q0AofUQ+u7Js3Fh2mxerwz5g==",
       "license": "MIT",
       "peerDependencies": {
-        "@mattermost/types": "10.12.0",
+        "@mattermost/types": "11.4.0",
         "typescript": "^4.3.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -591,9 +597,9 @@
       }
     },
     "node_modules/@mattermost/types": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@mattermost/types/-/types-10.12.0.tgz",
-      "integrity": "sha512-FGTpj7enl+2M9ElUyivW46K7j0/eGh6vrfPsw/C64W55In3yyal6YhLRv1UTGGSdmGwtLwZuFuv3Ot/kCIY8Jw==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@mattermost/types/-/types-11.4.0.tgz",
+      "integrity": "sha512-oYt7vvsa60hPpujcCBYeyd+22OwprEAtFXgVJrsdd9pR1qkEGU4F+uv8bh6ZTBSZAQnc2/xXQPZJGGR06toteA==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3.0 || ^5.0.0"

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "@github/copilot-sdk": "^0.1.32",
-    "@mattermost/client": "^10.3.0",
-    "@mattermost/types": "^10.3.0",
+    "@mattermost/client": "^11.4.0",
+    "@mattermost/types": "^11.4.0",
     "better-sqlite3": "^12.6.2",
     "cron": "^4.4.0",
     "cronstrue": "^3.13.0",


### PR DESCRIPTION
Combines dependabot PRs #51 and #52 into a single upgrade.

## Changes
- Bumps `@mattermost/client` from 10.x to 11.4.0
- Bumps `@mattermost/types` from 10.x to 11.4.0
- No code changes  all existing imports, API calls, and WebSocket polyfills are compatible with v11required 

## Validation
- `npx tsc --noEmit` passes cleanly
- All 166 tests pass

Closes #51
Closes #52