### PR TITLE
fix: /resume accepts partial session ID prefix

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -835,6 +835,18 @@ export class SessionManager {
     return this.contextUsage.get(channelId) ?? null;
   }
 
+  /**
+   * Resolve a session ID prefix to matching full session IDs.
+   * Returns all session IDs (for the channel's workspace) whose ID starts with the given prefix.
+   */
+  async resolveSessionPrefix(channelId: string, prefix: string): Promise<string[]> {
+    const sessions = await this.listChannelSessions(channelId);
+    const lower = prefix.toLowerCase();
+    return sessions
+      .filter(s => s.sessionId.toLowerCase().startsWith(lower))
+      .map(s => s.sessionId);
+  }
+
   /** List past sessions for this channel's working directory. */
   async listChannelSessions(channelId: string): Promise<Array<{ sessionId: string; startTime: Date; modifiedTime: Date; summary?: string; isCurrent: boolean }>> {
     const workingDirectory = this.resolveWorkingDirectory(channelId);

--- a/src/core/session-prefix.test.ts
+++ b/src/core/session-prefix.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests for resolveSessionPrefix matching logic.
+ * We test the pure filtering contract without instantiating SessionManager.
+ */
+
+function resolvePrefix(sessions: string[], prefix: string): string[] {
+  const lower = prefix.toLowerCase();
+  return sessions.filter(id => id.toLowerCase().startsWith(lower));
+}
+
+const SESSIONS = [
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  'a1b2c3d4-ffff-0000-1111-222233334444',
+  'deadbeef-1234-5678-9abc-def012345678',
+  'DEADBEEF-aaaa-bbbb-cccc-dddddddddddd',
+];
+
+describe('resolveSessionPrefix', () => {
+  it('matches an exact full session ID', () => {
+    const result = resolvePrefix(SESSIONS, 'a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+    expect(result).toEqual(['a1b2c3d4-e5f6-7890-abcd-ef1234567890']);
+  });
+
+  it('matches a short 8-char prefix (/status length)', () => {
+    const result = resolvePrefix(SESSIONS, 'deadbeef');
+    expect(result).toEqual([
+      'deadbeef-1234-5678-9abc-def012345678',
+      'DEADBEEF-aaaa-bbbb-cccc-dddddddddddd',
+    ]);
+  });
+
+  it('matches a 12-char prefix (/sessions length)', () => {
+    const result = resolvePrefix(SESSIONS, 'a1b2c3d4-fff');
+    expect(result).toEqual(['a1b2c3d4-ffff-0000-1111-222233334444']);
+  });
+
+  it('returns empty array when no sessions match', () => {
+    const result = resolvePrefix(SESSIONS, 'ffffffff');
+    expect(result).toEqual([]);
+  });
+
+  it('returns multiple matches for ambiguous prefix', () => {
+    const result = resolvePrefix(SESSIONS, 'a1b2c3d4');
+    expect(result).toEqual([
+      'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      'a1b2c3d4-ffff-0000-1111-222233334444',
+    ]);
+  });
+
+  it('matches case-insensitively', () => {
+    const result = resolvePrefix(SESSIONS, 'DEADBEEF-1234');
+    expect(result).toEqual(['deadbeef-1234-5678-9abc-def012345678']);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -751,7 +751,18 @@ async function handleInboundMessage(
         await finalizeActivityFeed(msg.channelId, adapter);
         const resumeAck = await adapter.sendMessage(msg.channelId, '⏳ Resuming session...', { threadRootId: threadRoot });
         try {
-          const resumedId = await sessionManager.resumeToSession(msg.channelId, cmdResult.payload);
+          const prefix = cmdResult.payload as string;
+          const matches = await sessionManager.resolveSessionPrefix(msg.channelId, prefix);
+          if (matches.length === 0) {
+            await adapter.updateMessage(msg.channelId, resumeAck, `❌ No session found matching prefix \`${prefix}\``);
+            break;
+          }
+          if (matches.length > 1) {
+            const list = matches.map((id: string) => `• \`${id.slice(0, 12)}\``).join('\n');
+            await adapter.updateMessage(msg.channelId, resumeAck, `⚠️ Ambiguous prefix \`${prefix}\` — matches multiple sessions:\n${list}\nPlease provide a longer prefix.`);
+            break;
+          }
+          const resumedId = await sessionManager.resumeToSession(msg.channelId, matches[0]);
           await adapter.updateMessage(msg.channelId, resumeAck, `✅ Resumed session \`${resumedId.slice(0, 8)}…\``);
         } catch (err: any) {
           await adapter.updateMessage(msg.channelId, resumeAck, `❌ Failed to resume session: ${err?.message ?? 'unknown error'}`);


### PR DESCRIPTION
Users can now paste the truncated session ID shown by `/status` (8 chars) and `/sessions` (12 chars) instead of needing the full GUID.

## Changes

- **`session-manager.ts`**: Added `resolveSessionPrefix(channelId, prefix)` method that filters sessions whose ID starts with the given prefix (case-insensitive)
- **`index.ts`**: Updated `resume_session` handler to resolve prefix before calling ` returns clear error for 0 matches, lists options for ambiguous matchesresumeToSession` 
- **`session-prefix.test.ts`**: 6 tests covering exact match, 8-char prefix, 12-char prefix, no match, ambiguous prefix, and case-insensitivity

Closes #42