### PR TITLE
fix: suppress thinking blocks from stream, preserve verbose messages

### DIFF
--- a/src/core/stream-formatter.test.ts
+++ b/src/core/stream-formatter.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { formatEvent } from './stream-formatter.js';
+
+describe('formatEvent', () => {
+  describe('thinking/reasoning suppression', () => {
+    it('returns null for assistant.reasoning events', () => {
+      const event = {
+        type: 'assistant.reasoning',
+        data: { reasoningId: 'r1', content: 'Let me think about this...' },
+      };
+      expect(formatEvent(event)).toBeNull();
+    });
+
+    it('returns null for assistant.reasoning_delta events', () => {
+      const event = {
+        type: 'assistant.reasoning_delta',
+        data: { reasoningId: 'r1', deltaContent: 'chunk of thinking' },
+      };
+      expect(formatEvent(event)).toBeNull();
+    });
+  });
+
+  describe('content events pass through', () => {
+    it('formats assistant.message_delta', () => {
+      const event = {
+        type: 'assistant.message_delta',
+        data: { deltaContent: 'Hello' },
+      };
+      const result = formatEvent(event);
+      expect(result).toEqual({ type: 'content', content: 'Hello', verbose: false });
+    });
+
+    it('formats assistant.message', () => {
+      const event = {
+        type: 'assistant.message',
+        data: { content: 'Full response' },
+      };
+      const result = formatEvent(event);
+      expect(result).toEqual({ type: 'content', content: 'Full response', verbose: false });
+    });
+  });
+
+  describe('streaming_delta is suppressed', () => {
+    it('returns null for assistant.streaming_delta', () => {
+      const event = { type: 'assistant.streaming_delta', data: { deltaContent: 'x' } };
+      expect(formatEvent(event)).toBeNull();
+    });
+  });
+
+  describe('tool events', () => {
+    it('formats tool.execution_start', () => {
+      const event = {
+        type: 'tool.execution_start',
+        data: { toolName: 'read_file', arguments: { path: '/tmp/test.ts' } },
+      };
+      const result = formatEvent(event);
+      expect(result?.type).toBe('tool_start');
+      expect(result?.verbose).toBe(true);
+      expect(result?.content).toContain('read_file');
+    });
+
+    it('formats tool.execution_complete', () => {
+      const event = {
+        type: 'tool.execution_complete',
+        data: { toolName: 'read_file', success: true },
+      };
+      const result = formatEvent(event);
+      expect(result?.type).toBe('tool_complete');
+      expect(result?.content).toContain('✅');
+    });
+  });
+
+  describe('unknown events', () => {
+    it('returns null for unrecognized event types', () => {
+      expect(formatEvent({ type: 'unknown.event' })).toBeNull();
+    });
+  });
+});

--- a/src/core/stream-formatter.ts
+++ b/src/core/stream-formatter.ts
@@ -23,6 +23,12 @@ export function formatEvent(event: any): FormattedEvent | null {
         verbose: false,
       };
 
+    // Suppress thinking/reasoning events — they cause message churn if
+    // streamed into the main content and then removed.
+    case 'assistant.reasoning':
+    case 'assistant.reasoning_delta':
+      return null;
+
     case 'tool.execution_start': {
       const toolName = event.data?.toolName ?? event.data?.name ?? 'unknown';
       const args = event.data?.arguments ?? {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1189,19 +1189,16 @@ async function handleSessionEvent(
         await finalizeActivityFeed(channelId, adapter);
       }
       // In verbose mode with an active "Working..." stream that hasn't received
-      // content yet, delete it and start a new stream so the response posts
-      // below the activity feed (no scroll-back).
+      // content yet, update it in place instead of deleting and recreating.
+      // This avoids visible message deletion/churn in the chat.
       if (verbose && streamKey) {
         const streamContent = streaming.getStreamContent(streamKey);
         if (streamContent !== undefined && streamContent === '') {
-          const threadRootId = streaming.getStreamThreadRootId(streamKey);
-          await streaming.deleteStream(streamKey);
-          activeStreams.delete(channelId);
-          const initialContent = event.type === 'assistant.message'
-            ? formatted.content
-            : (formatted.content || undefined);
-          const newKey = await streaming.startStream(channelId, threadRootId, initialContent);
-          activeStreams.set(channelId, newKey);
+          if (event.type === 'assistant.message') {
+            streaming.replaceContent(streamKey, formatted.content);
+          } else if (formatted.content) {
+            streaming.appendDelta(streamKey, formatted.content);
+          }
           adapter.setTyping(channelId).catch(() => {});
           break;
         }


### PR DESCRIPTION
## Summary

Fixes two streaming UX issues (#44):

### 1. Thinking blocks cause message churn
The SDK emits `assistant.reasoning` and `assistant.reasoning_delta` events for model thinking/extended reasoning. These were not handled in `stream-formatter.ts`, falling through to the default `null`  but any content leaking through during thinking phases caused visible churn.return 

**Fix:** Explicitly suppress `assistant.reasoning` and `assistant.reasoning_delta` in `formatEvent()`.

### 2. Verbose mode deletes messages
In verbose mode, empty "Working..." placeholder streams were deleted and recreated when content arrived, causing visible message deletion in chat.

**Fix:** Update the existing stream in place using `replaceContent()` / `appendDelta()` instead of `deleteStream()` + `startStream()`.

### Tests
Added `stream-formatter.test.ts` covering thinking suppression, content passthrough, tool events, and unknown event handling (8 tests).

Closes #44