### PR TITLE
fix: auto-deny permission on unrecognized text, process as new message

### DIFF
--- a/src/core/steering.test.ts
+++ b/src/core/steering.test.ts
@@ -92,3 +92,81 @@ describe('busyChannels state logic', () => {
     expect(busyChannels.has('ch-1')).toBe(false);
   });
 });
+
+/**
+ * Simulates the permission-check logic in handleMidTurnMessage (index.ts).
+ * Returns { action, text? } describing what should happen next.
+ */
+function handlePermissionDuringMidTurn(
+  hasPending: boolean,
+  text: string,
+  resolvePermission: (allow: boolean, remember?: boolean) => void,
+): { action: 'approve' | 'deny' | 'remember' | 'deny-and-continue'; text?: string } | null {
+  if (!hasPending) return null;
+  const lower = text.toLowerCase();
+  if (lower === '/approve' || lower === 'yes' || lower === 'y' || lower === 'approve') {
+    resolvePermission(true);
+    return { action: 'approve' };
+  }
+  if (lower === '/deny' || lower === 'no' || lower === 'n' || lower === 'deny') {
+    resolvePermission(false);
+    return { action: 'deny' };
+  }
+  if (lower === '/remember') {
+    resolvePermission(true, true);
+    return { action: 'remember' };
+  }
+  // Unrecognized text — auto-deny and fall through
+  resolvePermission(false);
+  return { action: 'deny-and-continue', text };
+}
+
+describe('permission handling during mid-turn', () => {
+  it('approves on /approve, yes, y, approve', () => {
+    for (const input of ['/approve', 'yes', 'y', 'approve', 'Yes', 'APPROVE']) {
+      const resolve = vi.fn();
+      const result = handlePermissionDuringMidTurn(true, input, resolve);
+      expect(result?.action).toBe('approve');
+      expect(resolve).toHaveBeenCalledWith(true);
+    }
+  });
+
+  it('denies on /deny, no, n, deny', () => {
+    for (const input of ['/deny', 'no', 'n', 'deny', 'No', 'DENY']) {
+      const resolve = vi.fn();
+      const result = handlePermissionDuringMidTurn(true, input, resolve);
+      expect(result?.action).toBe('deny');
+      expect(resolve).toHaveBeenCalledWith(false);
+    }
+  });
+
+  it('remembers on /remember', () => {
+    const resolve = vi.fn();
+    const result = handlePermissionDuringMidTurn(true, '/remember', resolve);
+    expect(result?.action).toBe('remember');
+    expect(resolve).toHaveBeenCalledWith(true, true);
+  });
+
+  it('auto-denies on unrecognized text and signals continue', () => {
+    const resolve = vi.fn();
+    const result = handlePermissionDuringMidTurn(true, 'actually use JWT instead', resolve);
+    expect(result?.action).toBe('deny-and-continue');
+    expect(result?.text).toBe('actually use JWT instead');
+    expect(resolve).toHaveBeenCalledWith(false);
+  });
+
+  it('auto-denies on slash commands and signals continue', () => {
+    const resolve = vi.fn();
+    const result = handlePermissionDuringMidTurn(true, '/new', resolve);
+    expect(result?.action).toBe('deny-and-continue');
+    expect(result?.text).toBe('/new');
+    expect(resolve).toHaveBeenCalledWith(false);
+  });
+
+  it('returns null when no permission is pending', () => {
+    const resolve = vi.fn();
+    const result = handlePermissionDuringMidTurn(false, 'hello', resolve);
+    expect(result).toBeNull();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -447,9 +447,9 @@ async function handleMidTurnMessage(
       sessionManager.resolvePermission(msg.channelId, true, true);
       return;
     }
-    // Other slash commands and unrecognized text while permission pending — ignore.
-    // They can't be queued on channelLocks (deadlock) and the permission must be resolved first.
-    return;
+    // Unrecognized text or slash commands — auto-deny the permission and
+    // fall through to process the message normally (mid-turn steering or command).
+    sessionManager.resolvePermission(msg.channelId, false);
   }
 
   // Slash commands while busy: handle safe ones immediately, defer the rest
@@ -998,6 +998,8 @@ async function handleInboundMessage(
       sessionManager.resolvePermission(msg.channelId, false);
       return;
     }
+    // Unrecognized text — auto-deny and fall through to process as a normal message
+    sessionManager.resolvePermission(msg.channelId, false);
   }
 
   // Regular message — forward to Copilot session


### PR DESCRIPTION
When a user sends arbitrary text during an active permission prompt, the permission is now auto-denied and the text is processed as a normal message instead of being silently discarded.

## Changes

**`src/index. Two locations updated:ts`** 

1. **Mid-turn handler** (`handleMidTurnMessage`): Instead of silently returning when unrecognized text arrives during a permission prompt, the permission is auto-denied and execution falls through to normal mid-turn steering (or slash command handling).

 `clearPendingPermissions` implicitly).

**`src/core/steering.test. Added 6 tests covering:ts`** 
- Approve/deny/remember keywords still work correctly
- Unrecognized text auto-denies and signals continuation
- Slash commands during permission prompt auto-deny and continue
- No-op when no permission is pending

Closes #50