### PR TITLE
chore: release v0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chrisromp/copilot-bridge",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chrisromp/copilot-bridge",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@github/copilot-sdk": "^0.1.32",
         "@mattermost/client": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrisromp/copilot-bridge",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Mattermost ↔ GitHub Copilot bridge",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump to 0.7.0. Merge to create the release tag.