### PR TITLE
ci: switch dev publish from auto to manual dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      publish_dev:
-        description: 'Publish a dev build to npm (tagged "dev")'
-        required: true
-        default: true
-        type: boolean
 
 permissions:
   contents: read


### PR DESCRIPTION
Dev versions were accumulating on npm with every merge to main (15 so far). Changes `publish-dev` trigger from `push: main` to `workflow_dispatch` so dev builds only publish when manually triggered from the Actions tab.