### PR TITLE
fix: scan .github/agents/ for agent definitions

### DIFF
--- a/src/core/command-handler.test.ts
+++ b/src/core/command-handler.test.ts
@@ -189,4 +189,21 @@ describe('/agents command', () => {
       fs.rmSync(fmDir, { recursive: true, force: true });
     }
   });
+
+  it('parses YAML block scalar descriptions', () => {
+    const fmDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmd-block-'));
+    const savedHome = process.env.HOME;
+    process.env.HOME = fmDir;
+    try {
+      const agentsDir = path.join(fmDir, 'agents');
+      fs.mkdirSync(agentsDir);
+      fs.writeFileSync(path.join(agentsDir, 'bob.agent.md'),
+        '---\nname: Bob\ndescription: >-\n  Use this agent for work prioritization\n  and meeting prep.\n---\n# Bob');
+      const result = handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: fmDir });
+      expect(result.response).toContain('Use this agent for work prioritization and meeting prep.');
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+      fs.rmSync(fmDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -123,7 +123,24 @@ function extractAgentDescription(content: string): string {
     for (let i = 1; i < lines.length; i++) {
       if (lines[i].trim() === '---') break; // end of frontmatter
       const match = lines[i].match(/^description:\s*(.+)/i);
-      if (match) return ` — ${match[1].trim().slice(0, 80)}`;
+      if (match) {
+        const value = match[1].trim();
+        // YAML block scalars (>-, |-, >, |): collect indented continuation lines
+        if (value === '>' || value === '>-' || value === '|' || value === '|-') {
+          const parts: string[] = [];
+          for (let j = i + 1; j < lines.length; j++) {
+            const line = lines[j];
+            if (line.trim() === '---') break; // end of frontmatter
+            if (line.match(/^\S/) && line.trim() !== '') break; // new YAML key
+            if (line.trim() === '') break; // blank line ends first paragraph
+            parts.push(line.trim());
+          }
+          if (parts.length > 0) return ` — ${parts.join(' ').slice(0, 120)}`;
+          return '';
+        }
+        // Inline or quoted value
+        return ` — ${value.replace(/^["']|["']$/g, '').slice(0, 120)}`;
+      }
     }
   }
   // Fallback: first non-heading, non-empty, non-frontmatter line
@@ -134,7 +151,7 @@ function extractAgentDescription(content: string): string {
       if (trimmed === '---' && i > 0) inFrontmatter = false;
       continue;
     }
-    if (trimmed && !trimmed.startsWith('#')) return ` — ${trimmed.slice(0, 80)}`;
+    if (trimmed && !trimmed.startsWith('#')) return ` — ${trimmed.slice(0, 120)}`;
   }
   return '';
 }
@@ -276,7 +293,7 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
       }
       const agents = discoverAgentDefinitions(agentsWorkDir);
       if (agents.size === 0) {
-        return { handled: true, response: 'No agent definitions found.\nPlace `*.agent.md` files in `<workspace>/agents/`, `~/.copilot/agents/`, or install a plugin with agents.' };
+        return { handled: true, response: 'No agent definitions found.\nPlace `*.agent.md` files in `<workspace>/agents/`, `<workspace>/.github/agents/`, `~/.copilot/agents/`, or install a plugin with agents.' };
       }
       const currentAgent = sessionInfo?.agent ?? null;
       const lines = ['**Available Agents**', ''];

--- a/src/core/inter-agent.test.ts
+++ b/src/core/inter-agent.test.ts
@@ -304,6 +304,29 @@ describe('discoverAgentDefinitions', () => {
     const defs = discoverAgentDefinitions(tmpDir);
     expect(defs.get('shared')!.content).toContain('Workspace version');
   });
+
+  it('discovers agents from .github/agents/', () => {
+    const ghAgents = path.join(tmpDir, '.github', 'agents');
+    fs.mkdirSync(ghAgents, { recursive: true });
+    fs.writeFileSync(path.join(ghAgents, 'bob.agent.md'), '# Bob\nA GitHub convention agent.');
+
+    const defs = discoverAgentDefinitions(tmpDir);
+    expect(defs.has('bob')).toBe(true);
+    expect(defs.get('bob')!.content).toContain('GitHub convention agent');
+  });
+
+  it('workspace agents/ overrides .github/agents/ of same name', () => {
+    const ghAgents = path.join(tmpDir, '.github', 'agents');
+    fs.mkdirSync(ghAgents, { recursive: true });
+    fs.writeFileSync(path.join(ghAgents, 'shared.agent.md'), '# .github version');
+
+    const wsAgents = path.join(tmpDir, 'agents');
+    fs.mkdirSync(wsAgents);
+    fs.writeFileSync(path.join(wsAgents, 'shared.agent.md'), '# agents/ version');
+
+    const defs = discoverAgentDefinitions(tmpDir);
+    expect(defs.get('shared')!.content).toContain('agents/ version');
+  });
 });
 
 describe('discoverAgentNames', () => {

--- a/src/core/inter-agent.ts
+++ b/src/core/inter-agent.ts
@@ -189,7 +189,8 @@ export function buildCallerPrompt(context: InterAgentContext): string {
  * Sources (later entries win on name conflicts):
  *   1. Installed plugins: ~/.copilot/installed-plugins/<vendor>/<plugin>/agents/
  *   2. User profile:      ~/.copilot/agents/
- *   3. Workspace:          <workspacePath>/agents/
+ *   3. Workspace .github:  <workspacePath>/.github/agents/
+ *   4. Workspace:          <workspacePath>/agents/
  */
 function getAgentRoots(workspacePath: string): { dir: string; source: AgentSource }[] {
   const roots: { dir: string; source: AgentSource }[] = [];
@@ -221,7 +222,11 @@ function getAgentRoots(workspacePath: string): { dir: string; source: AgentSourc
     if (fs.existsSync(userAgents)) roots.push({ dir: userAgents, source: 'user' });
   }
 
-  // 3. Workspace agents (highest priority — overrides earlier sources)
+  // 3. Workspace .github/agents/ (GitHub Copilot convention)
+  const ghAgents = path.join(workspacePath, '.github', 'agents');
+  if (fs.existsSync(ghAgents)) roots.push({ dir: ghAgents, source: 'workspace' });
+
+  // 4. Workspace agents/ (highest priority — overrides earlier sources)
   const wsAgents = path.join(workspacePath, 'agents');
   if (fs.existsSync(wsAgents)) roots.push({ dir: wsAgents, source: 'workspace' });
 

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -261,15 +261,19 @@ export function extractCommandPatterns(input: unknown): string[] {
 /**
  * Discover skill directories following Copilot CLI conventions:
  * - ~/.copilot/skills/ (user-level)
+ * - ~/.agents/skills/ (user-level)
  * - <workspace>/.github/skills/ (project-level)
- * - <workspace>/.agents/skills/ (project-level, legacy)
+ * - <workspace>/.agents/skills/ (project-level)
  */
 function discoverSkillDirectories(workingDirectory: string): string[] {
   const home = process.env.HOME;
   const roots: string[] = [];
 
   // User-level skills
-  if (home) roots.push(path.join(home, '.copilot', 'skills'));
+  if (home) {
+    roots.push(path.join(home, '.copilot', 'skills'));
+    roots.push(path.join(home, '.agents', 'skills'));
+  }
   // Project-level skills (standard)
   roots.push(path.join(workingDirectory, '.github', 'skills'));
   // Project-level skills (legacy)
@@ -393,6 +397,7 @@ export class SessionManager {
     const dirs = discoverSkillDirectories(workingDirectory);
     const sessionDirs = this.sessionSkillDirs.get(channelId);
     const skills: { name: string; description: string; source: string; pending?: boolean }[] = [];
+    const home = process.env.HOME;
 
     for (const dir of dirs) {
       const name = path.basename(dir);
@@ -403,6 +408,7 @@ export class SessionManager {
       // Determine source from path (normalize separators for cross-platform)
       const normalized = dir.split(path.sep).join('/');
       if (normalized.includes('.copilot/skills')) source = 'user';
+      else if (home && normalized.startsWith(home.split(path.sep).join('/') + '/.agents/skills')) source = 'user';
       else if (normalized.includes('.github/skills')) source = 'workspace';
       else if (normalized.includes('.agents/skills')) source = 'workspace';
 
@@ -693,17 +699,15 @@ export class SessionManager {
 
   /** Switch the agent for a channel's session. */
   async switchAgent(channelId: string, agent: string | null): Promise<void> {
-    const sessionId = this.channelSessions.get(channelId);
-    if (sessionId) {
-      try {
-        if (agent) {
-          await this.bridge.selectAgent(sessionId, agent);
-        } else {
-          await this.bridge.deselectAgent(sessionId);
-        }
-      } catch (err) {
-        log.warn(`RPC agent switch failed:`, err);
+    const { sessionId } = await this.ensureSession(channelId);
+    try {
+      if (agent) {
+        await this.bridge.selectAgent(sessionId, agent);
+      } else {
+        await this.bridge.deselectAgent(sessionId);
       }
+    } catch (err) {
+      log.warn(`RPC agent switch failed:`, err);
     }
     setChannelPrefs(channelId, { agent });
   }


### PR DESCRIPTION
## Summary

Fix agent and skill discovery to match GitHub Copilot CLI conventions, plus related improvements.

## Changes

- **`src/core/inter-agent.ts`**: Added `.github/agents/` as a workspace-level agent discovery path. Updated priority comments.
- **`src/core/session-manager.ts`**: Added `~/.agents/skills/` as user-level skill discovery path. Fixed source detection for user-level `.agents/skills/`. Used `ensureSession()` in `switchAgent` to resume session before RPC call.
- **`src/core/command-handler.ts`**: Updated `/agents` help text to mention `.github/agents/`. Parse YAML block scalar descriptions (`>-`, `|-`, `>`, `|`) in agent frontmatter.
- **`src/core/inter-agent.test.ts`**: Added tests for `.github/agents/` discovery and priority vs `agents/`.
- **`src/core/command-handler.test.ts`**: Added test for YAML block scalar description parsing.

## Testing

352 tests pass, type-check clean.

Closes #93