### PR TITLE
fix: /reasoning applies immediately by recreating session

### DIFF
--- a/src/core/command-handler.test.ts
+++ b/src/core/command-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { handleCommand, parseCommand } from './command-handler.js';
+import { handleCommand, parseCommand, type ModelInfo } from './command-handler.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -304,5 +304,42 @@ describe('/status command', () => {
   it('shows no active session when no sessionInfo', () => {
     const result = handleCommand('ch-status-none', '/status');
     expect(result.response).toContain('No active session');
+  });
+});
+
+describe('/reasoning command', () => {
+  const SESSION_INFO = { sessionId: 'sess-123', model: 'claude-opus-4.6', agent: null };
+  const REASONING_MODEL: ModelInfo = {
+    id: 'claude-opus-4.6',
+    name: 'Claude Opus 4.6',
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+  };
+
+  it('returns set_reasoning action with valid level', () => {
+    const result = handleCommand('ch-reason-1', '/reasoning high', SESSION_INFO,
+      { verbose: false, permissionMode: 'interactive', reasoningEffort: null },
+      undefined, [REASONING_MODEL]);
+    expect(result.handled).toBe(true);
+    expect(result.action).toBe('set_reasoning');
+    expect(result.payload).toBe('high');
+    expect(result.response).toContain('Creating new session');
+    expect(result.response).not.toContain('next session');
+  });
+
+  it('rejects invalid reasoning level', () => {
+    const result = handleCommand('ch-reason-2', '/reasoning banana', SESSION_INFO,
+      { verbose: false, permissionMode: 'interactive', reasoningEffort: null },
+      undefined, [REASONING_MODEL]);
+    expect(result.handled).toBe(true);
+    expect(result.action).toBeUndefined();
+    expect(result.response).toContain('Invalid reasoning effort');
+  });
+
+  it('shows current level when no args', () => {
+    const result = handleCommand('ch-reason-3', '/reasoning', SESSION_INFO,
+      { verbose: false, permissionMode: 'interactive', reasoningEffort: 'high' });
+    expect(result.handled).toBe(true);
+    expect(result.response).toContain('Current reasoning effort: **high**');
   });
 });

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -340,7 +340,7 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
         handled: true,
         action: 'set_reasoning',
         payload: level,
-        response: `🧠 Reasoning effort set to **${level}**. Takes effect on next session (\`/new\`).`,
+        response: `🧠 Reasoning effort set to **${level}**. Creating new session...`,
       };
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -650,7 +650,7 @@ async function handleMidTurnMessage(
     // Commands with complex action handlers (skills, schedule, rules) defer to serialized path.
     const SAFE_MID_TURN = new Set([
       'context', 'status', 'help', 'verbose', 'yolo',
-      'model', 'models', 'reasoning', 'agents',
+      'model', 'models', 'agents',
       'streamer-mode', 'on-air',
     ]);
 
@@ -659,7 +659,7 @@ async function handleMidTurnMessage(
       const sessionInfo = sessionManager.getSessionInfo(msg.channelId);
       const effPrefs = sessionManager.getEffectivePrefs(msg.channelId);
       let models: any[] | undefined;
-      if (['model', 'models', 'status', 'reasoning'].includes(parsed.command)) {
+      if (['model', 'models', 'status'].includes(parsed.command)) {
         try { models = await sessionManager.listModels(); } catch { models = undefined; }
       }
       const mcpInfo = undefined;
@@ -831,7 +831,7 @@ async function handleInboundMessage(
     const threadRoot = resolveThreadRoot(msg, threadRequested, channelConfig);
 
     // Send response before action, except for actions that send their own ack after completing
-    const deferResponse = cmdResult.action === 'switch_model' || cmdResult.action === 'switch_agent';
+    const deferResponse = cmdResult.action === 'switch_model' || cmdResult.action === 'switch_agent' || cmdResult.action === 'set_reasoning';
     if (cmdResult.response && !deferResponse) {
       await adapter.sendMessage(msg.channelId, cmdResult.response, { threadRootId: threadRoot });
     }
@@ -974,6 +974,25 @@ async function handleInboundMessage(
         } catch (err: any) {
           log.error(`Failed to switch agent on ${msg.channelId.slice(0, 8)}...:`, err);
           await adapter.updateMessage(msg.channelId, ackId, '❌ Failed to switch agent. Check logs for details.');
+        }
+        break;
+      }
+      case 'set_reasoning': {
+        const ackId = await adapter.sendMessage(msg.channelId, `🧠 Reasoning effort set to **${cmdResult.payload}**. Creating new session...`, { threadRootId: threadRoot });
+        try {
+          markIdleImmediate(msg.channelId);
+          const oldStreamKey = activeStreams.get(msg.channelId);
+          if (oldStreamKey) {
+            await streaming.cancelStream(oldStreamKey);
+            activeStreams.delete(msg.channelId);
+          }
+          await finalizeActivityFeed(msg.channelId, adapter);
+          loopDetector.reset(msg.channelId);
+          await sessionManager.newSession(msg.channelId);
+          await adapter.updateMessage(msg.channelId, ackId, `🧠 Reasoning effort set to **${cmdResult.payload}**. New session created.`);
+        } catch (err: any) {
+          log.error(`Failed to apply reasoning effort on ${msg.channelId.slice(0, 8)}...:`, err);
+          await adapter.updateMessage(msg.channelId, ackId, `🧠 Reasoning effort saved to **${cmdResult.payload}** but session recreation failed. Use \`/new\` to apply.`);
         }
         break;
       }


### PR DESCRIPTION
## Summary

Makes `/reasoning` apply immediately by automatically recreating the session, instead of requiring a manual `/new`.

### What it does

- `/reasoning <level>` now saves the pref AND recreates the session in one step
- The SDK has no mid-session RPC for reasoning effort (it is a creation-time config only), so session recreation is required
- Graceful error handling: if session recreation fails, the pref is still saved and the user can `/new` manually

### Key changes

- `src/index.ts`: Add `set_reasoning` action handler that cleans up streams, resets loop detector, and calls `newSession()`
- `src/index.ts`: Remove `reasoning` from `SAFE_MID_TURN` set (not safe since it needs session recreation)
- `src/core/command-handler.ts`: Update response message from "Takes effect on next session" to "Creating new session"
- `src/core/command-handler.test.ts`: 3 tests for /reasoning command (valid level, invalid level, show current)

### Why session recreation?

The GitHub Copilot SDK only accepts `reasoningEffort` at session creation time (`SessionConfig`). Unlike model switching (`session.rpc.model.switchTo()`), there is no equivalent RPC for reasoning effort. The CLI itself likely does the same thing internally.

Fixes [#99](https://github.com/ChrisRomp/copilot-bridge/issues/99)
