### PR TITLE
feat: discover skills from installed plugins

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -433,7 +433,8 @@ export class SessionManager {
 
       // Determine source from path (normalize separators for cross-platform)
       const normalized = dir.split(path.sep).join('/');
-      if (normalized.includes('.copilot/skills')) source = 'user';
+      if (normalized.includes('installed-plugins') && normalized.includes('/skills')) source = 'plugin';
+      else if (normalized.includes('.copilot/skills')) source = 'user';
       else if (home && normalized.startsWith(home.split(path.sep).join('/') + '/.agents/skills')) source = 'user';
       else if (normalized.includes('.github/skills')) source = 'workspace';
       else if (normalized.includes('.agents/skills')) source = 'workspace';


### PR DESCRIPTION
## Summary

Discovers skills from installed plugins (`~/.copilot/installed-plugins/`), closing a gap where only MCP servers and agents were loaded from plugins.

### What it does
- Walks `~/.copilot/installed-plugins/` up to 3 levels deep looking for `skills/` directories
- Appends plugin skill directories after user/workspace sources so they have lowest priority (first-found-wins per CLI spec)
- Matches the existing pattern used for agent discovery in `inter-agent.ts`

### Key changes
- `src/core/session-manager.ts`: Extended `discoverSkillDirectories()` with plugin walk

### Loading order (first-found-wins)
1. User-level: `~/.copilot/skills/`, `~/.agents/skills/`
2. Workspace: `<workspace>/.github/skills/`, `<workspace>/.agents/skills/`
3. Plugins: `~/.copilot/installed-plugins/**/skills/` (lowest priority)

Related: [#104](https://github.com/ChrisRomp/copilot-bridge/issues/104) tracks hooks support (separate primitive).
