### PR TITLE
fix: suppress NO_REPLY streaming with unified quiet mode

### DIFF
--- a/src/core/quiet-mode.test.ts
+++ b/src/core/quiet-mode.test.ts
@@ -12,13 +12,10 @@ afterEach(() => {
 });
 
 describe('enterQuietMode / exitQuietMode', () => {
-  it('sets quiet state with hasContent false', () => {
+  it('sets quiet state', () => {
     enterQuietMode('ch1');
     expect(isQuiet('ch1')).toBe(true);
-    const qs = getQuietState('ch1');
-    expect(qs).toBeDefined();
-    expect(qs!.hasContent).toBe(false);
-    expect(qs!.threadRoot).toBeUndefined();
+    expect(getQuietState('ch1')).toBeDefined();
   });
 
   it('channels are independent', () => {
@@ -100,21 +97,12 @@ describe('timeout safety net', () => {
   });
 });
 
-describe('hasContent tracking', () => {
-  it('starts false and can be set true', () => {
+describe('getQuietState', () => {
+  it('returns state when quiet, undefined otherwise', () => {
+    expect(getQuietState('ch1')).toBeUndefined();
     enterQuietMode('ch1');
-    const qs = getQuietState('ch1')!;
-    expect(qs.hasContent).toBe(false);
-    qs.hasContent = true;
-    expect(getQuietState('ch1')!.hasContent).toBe(true);
-  });
-});
-
-describe('threadRoot preservation', () => {
-  it('can store threadRoot for delayed stream creation', () => {
-    enterQuietMode('ch1');
-    const qs = getQuietState('ch1')!;
-    qs.threadRoot = 'thread-abc';
-    expect(getQuietState('ch1')!.threadRoot).toBe('thread-abc');
+    expect(getQuietState('ch1')).toBeDefined();
+    exitQuietMode('ch1');
+    expect(getQuietState('ch1')).toBeUndefined();
   });
 });

--- a/src/core/quiet-mode.ts
+++ b/src/core/quiet-mode.ts
@@ -7,8 +7,6 @@ import { createLogger } from '../logger.js';
 const log = createLogger('quiet');
 
 export interface QuietState {
-  threadRoot?: string;       // preserve for delayed stream creation on flush
-  hasContent: boolean;       // any non-empty deltas received?
   timeout: ReturnType<typeof setTimeout>;  // 60s safety net
 }
 
@@ -26,7 +24,7 @@ export function enterQuietMode(channelId: string): () => void {
     state.delete(channelId);
   }, TIMEOUT_MS);
 
-  state.set(channelId, { hasContent: false, timeout });
+  state.set(channelId, { timeout });
   return () => {
     const qs = state.get(channelId);
     if (qs) { clearTimeout(qs.timeout); state.delete(channelId); }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { initScheduler, stopAll as stopScheduler, listJobs, removeJob, pauseJob,
 import { markBusy, markIdle, markIdleImmediate, isBusy, waitForChannelIdle, cancelIdleDebounce } from './core/channel-idle.js';
 import { LoopDetector, MAX_IDENTICAL_CALLS } from './core/loop-detector.js';
 import { checkUserAccess } from './core/access-control.js';
-import { enterQuietMode, exitQuietMode, getQuietState, isQuiet } from './core/quiet-mode.js';
+import { enterQuietMode, exitQuietMode, isQuiet } from './core/quiet-mode.js';
 import { createLogger, setLogLevel } from './logger.js';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -557,7 +557,6 @@ async function main(): Promise<void> {
           // Hold the lock until the response is fully streamed
           await waitForChannelIdle(channelId);
         } catch (err: any) {
-          clearQuiet();
           log.error(`Scheduled job sendMessage failed for ${channelId.slice(0, 8)}...:`, err);
           markIdleImmediate(channelId);
           const failedStream = activeStreams.get(channelId);
@@ -567,6 +566,8 @@ async function main(): Promise<void> {
             activeStreams.delete(channelId);
           }
           throw err;
+        } finally {
+          clearQuiet();
         }
       });
       channelLocks.set(channelId, task.catch(() => {}));
@@ -1937,13 +1938,10 @@ async function handleSessionEvent(
   if (!formatted) return;
 
   // ── Quiet mode: suppress all output until we know if response is NO_REPLY ──
-  const qs = getQuietState(channelId);
-  if (qs) {
+  if (isQuiet(channelId)) {
     // Suppress content events (deltas and messages)
     if (formatted.type === 'content') {
       if (event.type === 'assistant.message_delta') {
-        // Don't render — just note that content arrived
-        if (formatted.content?.trim()) qs.hasContent = true;
         return;
       }
       if (event.type === 'assistant.message') {
@@ -1960,7 +1958,7 @@ async function handleSessionEvent(
         }
         // Real content — flush: create stream with this content, exit quiet
         log.info(`Quiet mode flush on channel ${channelId.slice(0, 8)}... — real content received`);
-        const savedThreadRoot = qs.threadRoot ?? channelThreadRoots.get(channelId);
+        const savedThreadRoot = channelThreadRoots.get(channelId);
         exitQuietMode(channelId);
         const newKey = await streaming.startStream(channelId, savedThreadRoot, content);
         activeStreams.set(channelId, newKey);
@@ -1975,7 +1973,7 @@ async function handleSessionEvent(
     if (formatted.type === 'status' && event.type !== 'session.idle') {
       return;
     }
-    // Suppress errors — clear quiet and let error handler run below
+    // Errors: exit quiet and fall through to normal error handling (surfaces to user)
     if (formatted.type === 'error') {
       exitQuietMode(channelId);
       // Fall through to normal error handling
@@ -2232,9 +2230,8 @@ async function nudgeAdminSessions(sessionManager: SessionManager): Promise<void>
       const clearQuiet = enterQuietMode(channelId);
       try {
         await sessionManager.sendMessage(channelId, NUDGE_PROMPT);
-      } catch (err) {
+      } finally {
         clearQuiet();
-        throw err;
       }
     } catch (err) {
       exitQuietMode(channelId);


### PR DESCRIPTION
## Summary
Replaces the simple `nudgePending` Set with a unified quiet mode system that fully suppresses all streaming output until we determine whether the response is `NO_REPLY`.

### What it does
- Suppresses **all** streaming events (deltas, tool activity, status, permissions, user input) during startup nudges and scheduled tasks
- Defers stream creation  no more "Working..." flash before `NO_REPLY` responsesentirely 
- Flushes with real content via `initialContent` when the response is not `NO_REPLY`
- Auto-denies permissions and resolves user input requests during quiet mode (prevents session deadlock)
- 60s timeout safety net per quiet state entry

### Key changes
- `src/core/quiet-mode.ts`: New  `QuietState` interface, `enterQuietMode()`, `exitQuietMode()`, `getQuietState()`, `isQuiet()`module 
- `src/core/quiet-mode.test.ts`: 13 tests covering lifecycle, timeout, cleanup, state tracking
- `src/index.ts`: Wires quiet mode into event handler, scheduler wrapper, and nudge function; removes inline `nudgePending` code

### Design decisions
1. **Don't buffer  just track `hasContent` boolean. Use `assistant.message` content (authoritative) for flush.deltas** 
2. **Skip empty `assistant. SDK fires these as tool-call signals before tool execution.message`** 
3. **Let `session.idle` pass  so `markIdle()` fires and `waitForChannelIdle()` resolves normally.through** 
4. **Resolve (not just suppress) permissions/ prevents SDK session deadlock on unresolved promises.input** 

Closes [#119](https://github.com/ChrisRomp/copilot-bridge/issues/119)