### PR TITLE
feat(beads): add Beads integration docs, skill template, and config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,3 +131,42 @@ Use the repo's YAML issue templates (`.github/ISSUE_TEMPLATE/`) when creating is
 
 Always set `Reported By: Agent (automated)` when filing programmatically. Reference related issues with `#N`. Keep issue bodies factual — describe observed behavior, not speculative fixes.
 
+## Review-Implement Loop (REQUIRED)
+
+Every code change MUST go through the review-implement loop before being considered done. This is non-negotiable.
+
+### The Loop
+
+```
+Write -> Test -> Review -> Fix (if needed) -> Re-review -> Open PR
+```
+
+1. **Write**: Implement the change, run tests, commit and push
+2. **Review**: Launch a `Review` agent against the diff (e.g., `git diff HEAD~1 HEAD` or the PR diff)
+3. **Triage**: Read findings. If 0 Critical/High/Medium issues, skip to step 6
+4. **Fix**: Address the findings, commit, push, verify tests pass
+5. **Re-review**: Launch Review agent again scoped to fix commits
+6. **Repeat** steps 3-5 until review is clean (max 3 cycles, then escalate to user)
+7. **Open PR**: Only after review is clean, tests pass, and spot-check succeeds. PRs are the deliverable.
+
+### Merge Gate
+
+A change may only be considered complete when:
+- Latest code review finds no Critical or High issues
+- All tests pass
+- Any Medium issues are either fixed or explicitly accepted by the user
+
+### Test Quality Gate (Anti-False-Positive)
+
+When reviewing tests, the Review agent MUST check for false positives by asking:
+
+> "Would this test still pass if the feature under test were completely removed or disabled?"
+
+If yes, the test is a false positive. Tests must create **state divergence** where the feature's absence produces a different observable outcome. See the parent AGENTS.md for patterns (cache divergence, side-effect assertions, config-flag tests).
+
+### When to Run
+
+- After **every** commit that changes source code (not docs-only changes)
+- Even for "simple" or "obvious" changes; the review catches what you miss
+- The loop runs automatically; never ask the user whether to review
+

--- a/config.sample.json
+++ b/config.sample.json
@@ -49,9 +49,9 @@
       "shell(tail)",
       "shell(find)",
       "shell(grep)",
-      "shell(wc)",
-      "shell(bd)"
+      "shell(wc)"
     ],
+    "_comment_beads": "Uncomment to allow Beads task memory (bd writes to .beads/ and may start a Dolt server — opt-in only)",
     "deny": [
       "shell(rm)",
       "shell(git push)",

--- a/config.sample.json
+++ b/config.sample.json
@@ -49,7 +49,8 @@
       "shell(tail)",
       "shell(find)",
       "shell(grep)",
-      "shell(wc)"
+      "shell(wc)",
+      "shell(bd)"
     ],
     "deny": [
       "shell(rm)",

--- a/docs/beads.md
+++ b/docs/beads.md
@@ -40,34 +40,35 @@ Add to `<workspace>/.env`:
 ```bash
 BEADS_DIR=<workspace>/.beads
 BEADS_ACTOR={{botName}}
-PATH=/home/<user>/.local/bin:$PATH   # if dolt is not on system PATH
 ```
+
+> **Note:** copilot-bridge's `.env` parser does not expand shell variables like `$PATH`. If Dolt is not on the system PATH, set it in the hook scripts directly (see Session Hook Automation below) rather than in `.env`.
 
 copilot-bridge auto-injects `.env` variables into all MCP server environments. The `BEADS_ACTOR` variable sets the actor name in the Beads audit trail — use the bot name for clear attribution.
 
-### 3. Add the skill file
+### 3. Add the Beads agent definition
 
-Copy `templates/agents/beads.agent.md` to the workspace's skill directory (typically `.github/agents/`):
+Copy `templates/agents/beads.agent.md` to the workspace's agents directory (`.github/agents/`):
 
 ```bash
 cp templates/agents/beads.agent.md <workspace>/.github/agents/beads.agent.md
 ```
 
-copilot-bridge automatically discovers and surfaces skill files in `.github/agents/` to the agent. The agent will use this to learn the `bd` workflow without any system prompt changes.
+This adds a `beads` agent definition that agents can switch to with `/agent beads`. It provides the full `bd` workflow and is automatically discovered by copilot-bridge from `.github/agents/`.
 
 ### 4. Update AGENTS.md (optional)
 
-Add a brief Beads section to the workspace `AGENTS.md` so the agent knows to use it. The skill file (`beads.agent.md`) contains the full command reference — `AGENTS.md` just needs a pointer:
+Add a brief Beads section to the workspace `AGENTS.md` so the default agent knows to use `bd` when available:
 
 ```markdown
 ## Task Memory (Beads)
 
-This workspace uses Beads (`bd`) for persistent task tracking. See the `Beads Task Memory` skill for the full workflow. Use `bd prime` at session start and `bd backup export-git` at session end.
+This workspace uses Beads (`bd`) for persistent task tracking. Use `/agent beads` for the full workflow, or see `docs/beads.md` for setup. Use `bd prime` at session start and `bd backup export-git` at session end.
 ```
 
-### 5. Add `bd` to workspace permissions (optional)
+### 5. Add `bd` to workspace permissions (opt-in)
 
-If using `permissionMode: "auto"`, add `bd` to the workspace allow list in `config.json`:
+`bd` writes to `.beads/` and may start a Dolt server — it is intentionally **not** in the default allow list. Add it explicitly if you want agents to run it without interactive prompts:
 
 ```json
 "permissions": {
@@ -75,13 +76,14 @@ If using `permissionMode: "auto"`, add `bd` to the workspace allow list in `conf
 }
 ```
 
-Or use the blanket `"shell"` allow if the workspace is fully trusted.
-
 ## Session Hook Automation (Recommended)
 
 Rather than relying on the agent to remember to run `bd prime` and `bd backup export-git`, use copilot-bridge session hooks to automate them.
 
-> **Note:** Session hooks require `allowWorkspaceHooks: true` in `~/.copilot-bridge/config.json`.
+> **Note:** Session hooks require `allowWorkspaceHooks: true` under `defaults` in `~/.copilot-bridge/config.json`:
+> ```json
+> "defaults": { "allowWorkspaceHooks": true }
+> ```
 
 ### hooks.json
 
@@ -111,7 +113,11 @@ Create `<workspace>/.github/hooks/hooks.json`:
 }
 ```
 
+> **Note:** `cwd` is relative to the directory containing `hooks.json`. Use `"."` — do not repeat the hooks directory path.
+
 ### session-start.sh
+
+Hook scripts run as separate processes and do not inherit workspace `.env`. Set `BEADS_DIR` and `PATH` explicitly:
 
 ```bash
 #!/usr/bin/env bash
@@ -119,11 +125,15 @@ set -euo pipefail
 
 input=$(cat)  # JSON from copilot-bridge: { "sessionId": "...", "channelId": "..." }
 
+export PATH="/home/<user>/.local/bin:$PATH"   # ensure dolt is on PATH
+export BEADS_DIR="<workspace>/.beads"
+export BEADS_ACTOR="{{botName}}"
+
 if command -v bd &>/dev/null; then
   bd prime >/dev/null 2>&1 || true
 fi
 
-# Return empty JSON — hooks-loader expects JSON output from hook scripts
+# hooks-loader expects JSON output — return empty object
 echo '{}'
 ```
 
@@ -135,11 +145,15 @@ set -euo pipefail
 
 input=$(cat)  # JSON from copilot-bridge: { "sessionId": "...", "channelId": "..." }
 
+export PATH="/home/<user>/.local/bin:$PATH"   # ensure dolt is on PATH
+export BEADS_DIR="<workspace>/.beads"
+export BEADS_ACTOR="{{botName}}"
+
 if command -v bd &>/dev/null; then
   bd backup export-git >/dev/null 2>&1 || true
 fi
 
-# Return empty JSON — hooks-loader expects JSON output from hook scripts
+# hooks-loader expects JSON output — return empty object
 echo '{}'
 ```
 

--- a/docs/beads.md
+++ b/docs/beads.md
@@ -1,0 +1,217 @@
+# Beads Integration Guide
+
+[Beads](https://github.com/steveyegge/beads) (`bd`) is a distributed, Dolt-backed graph issue tracker designed for AI agent memory. This guide covers integrating Beads into a copilot-bridge workspace so agents can persist task context across session restarts.
+
+## Why Beads Instead of MEMORY.md
+
+`MEMORY.md` is a flat markdown file — simple, but limited:
+
+| | `MEMORY.md` | Beads |
+|---|---|---|
+| Queryable | ❌ | ✅ `bd search`, `bd ready`, `bd blocked` |
+| Dependency tracking | ❌ | ✅ `bd dep add` |
+| Concurrency-safe | ❌ | ✅ Dolt atomic commits |
+| Versioned / auditable | ❌ | ✅ Full Dolt history |
+| Cross-session recovery | Manual | ✅ `bd prime` |
+| Multi-bot coordination | ❌ | ✅ Shared Dolt server or remote sync |
+
+## Prerequisites
+
+- **`bd` CLI**: `npm install -g @beads/bd` or `brew install beads`
+- **Dolt**: installed automatically when `bd` first runs — no manual setup needed
+- Node.js 18+ (for `bd` CLI)
+
+## Workspace Setup
+
+### 1. Initialize Beads
+
+Run from inside the workspace directory:
+
+```bash
+bd init --quiet --stealth
+```
+
+`--stealth` disables git hooks and git operations from Beads — required for copilot-bridge workspaces where the bot should not push git changes autonomously.
+
+### 2. Configure the workspace `.env`
+
+Add to `<workspace>/.env`:
+
+```bash
+BEADS_DIR=<workspace>/.beads
+BEADS_ACTOR={{botName}}
+PATH=/home/<user>/.local/bin:$PATH   # if dolt is not on system PATH
+```
+
+copilot-bridge auto-injects `.env` variables into all MCP server environments. The `BEADS_ACTOR` variable sets the actor name in the Beads audit trail — use the bot name for clear attribution.
+
+### 3. Add the skill file
+
+Copy `templates/agents/beads.agent.md` to the workspace's skill directory (typically `.github/agents/`):
+
+```bash
+cp templates/agents/beads.agent.md <workspace>/.github/agents/beads.agent.md
+```
+
+copilot-bridge automatically discovers and surfaces skill files in `.github/agents/` to the agent. The agent will use this to learn the `bd` workflow without any system prompt changes.
+
+### 4. Update AGENTS.md (optional)
+
+Add a brief Beads section to the workspace `AGENTS.md` so the agent knows to use it. The skill file (`beads.agent.md`) contains the full command reference — `AGENTS.md` just needs a pointer:
+
+```markdown
+## Task Memory (Beads)
+
+This workspace uses Beads (`bd`) for persistent task tracking. See the `Beads Task Memory` skill for the full workflow. Use `bd prime` at session start and `bd backup export-git` at session end.
+```
+
+### 5. Add `bd` to workspace permissions (optional)
+
+If using `permissionMode: "auto"`, add `bd` to the workspace allow list in `config.json`:
+
+```json
+"permissions": {
+  "allow": ["shell(bd)"]
+}
+```
+
+Or use the blanket `"shell"` allow if the workspace is fully trusted.
+
+## Session Hook Automation (Recommended)
+
+Rather than relying on the agent to remember to run `bd prime` and `bd backup export-git`, use copilot-bridge session hooks to automate them.
+
+> **Note:** Session hooks require `allowWorkspaceHooks: true` in `~/.copilot-bridge/config.json`.
+
+### hooks.json
+
+Create `<workspace>/.github/hooks/hooks.json`:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "./session-start.sh",
+        "cwd": ".",
+        "timeoutSec": 15
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": "./session-end.sh",
+        "cwd": ".",
+        "timeoutSec": 30
+      }
+    ]
+  }
+}
+```
+
+### session-start.sh
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inject bd prime output as context at session start
+input=$(cat)  # JSON from copilot-bridge: { "sessionId": "...", "channelId": "..." }
+
+if command -v bd &>/dev/null; then
+  bd prime 2>/dev/null || true
+fi
+```
+
+### session-end.sh
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+input=$(cat)  # JSON from copilot-bridge: { "sessionId": "...", "channelId": "..." }
+
+if command -v bd &>/dev/null; then
+  bd backup export-git 2>/dev/null || true
+fi
+```
+
+Make both scripts executable: `chmod +x session-start.sh session-end.sh`
+
+## Sync Strategy
+
+Beads provides three tiers of persistence:
+
+| Tier | Command | Use case |
+|------|---------|----------|
+| **Local (automatic)** | *(none)* | Every write auto-commits to local Dolt history — always on |
+| **Git branch backup** | `bd backup export-git` | JSONL snapshot to a git branch in the workspace repo — zero new infrastructure |
+| **Full Dolt sync** | `bd dolt push` | Push to DoltHub, S3, GCS, or `git+ssh://` remote — multi-machine access |
+
+**Recommended per scenario:**
+
+- **Single bot, single machine**: `bd backup export-git` in `sessionEnd` hook — JSONL snapshots stored in the existing workspace git repo
+- **Multi-machine / disaster recovery**: `bd dolt remote add origin git+ssh://git@github.com/org/repo.git` + `bd dolt push` in hook. Dolt stores its data under `refs/dolt/data` — invisible to normal git, compatible with any existing GitHub repo
+- **Multiple bots on the same host**: set `BEADS_DOLT_SHARED_SERVER=1` in workspace `.env` — single shared Dolt server, each bot isolated in its own database
+
+## MCP Alternative
+
+For environments where the agent does not have shell access, `beads-mcp` provides the same functionality as a stdio MCP server:
+
+```bash
+uv tool install beads-mcp
+```
+
+Add to `<workspace>/mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "beads": {
+      "command": "beads-mcp",
+      "env": {
+        "BEADS_WORKING_DIR": "{{workspacePath}}",
+        "BEADS_ACTOR": "{{botName}}"
+      }
+    }
+  }
+}
+```
+
+> **Token cost**: `beads-mcp` exposes tool schemas that consume 10–50k tokens per session. The CLI approach via skill file is preferred for shell-capable agents.
+
+## Troubleshooting
+
+**`bd` can't find `dolt`**
+Dolt installs to `~/.local/bin/` by default. Ensure this is on `PATH` in the workspace `.env`:
+```bash
+PATH=/home/<user>/.local/bin:$PATH
+```
+
+**Dolt server not starting**
+```bash
+bd doctor       # Check server health
+bd dolt start   # Start manually
+```
+
+**`.beads/` not tracked by git**
+`bd init --stealth` adds `.beads/` to `.git/info/exclude`. To commit Beads config files (e.g., `.beads/config.yaml`), remove that line:
+```bash
+grep -v "^\.beads" .git/info/exclude > /tmp/exclude && mv /tmp/exclude .git/info/exclude
+```
+
+Add Dolt binary data to `.gitignore` to avoid committing large files:
+```
+.beads/dolt/
+.beads/*.db
+```
+
+## References
+
+- [Beads GitHub](https://github.com/steveyegge/beads)
+- [Beads ARCHITECTURE.md](https://github.com/steveyegge/beads/blob/main/docs/ARCHITECTURE.md)
+- [Beads DOLT-BACKEND.md](https://github.com/steveyegge/beads/blob/main/docs/DOLT-BACKEND.md)
+- [beads-mcp on PyPI](https://pypi.org/project/beads-mcp/)
+- copilot-bridge issue [#157](https://github.com/ChrisRomp/copilot-bridge/issues/157) — integration tracking

--- a/docs/beads.md
+++ b/docs/beads.md
@@ -117,12 +117,14 @@ Create `<workspace>/.github/hooks/hooks.json`:
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Inject bd prime output as context at session start
 input=$(cat)  # JSON from copilot-bridge: { "sessionId": "...", "channelId": "..." }
 
 if command -v bd &>/dev/null; then
-  bd prime 2>/dev/null || true
+  bd prime >/dev/null 2>&1 || true
 fi
+
+# Return empty JSON — hooks-loader expects JSON output from hook scripts
+echo '{}'
 ```
 
 ### session-end.sh
@@ -134,8 +136,11 @@ set -euo pipefail
 input=$(cat)  # JSON from copilot-bridge: { "sessionId": "...", "channelId": "..." }
 
 if command -v bd &>/dev/null; then
-  bd backup export-git 2>/dev/null || true
+  bd backup export-git >/dev/null 2>&1 || true
 fi
+
+# Return empty JSON — hooks-loader expects JSON output from hook scripts
+echo '{}'
 ```
 
 Make both scripts executable: `chmod +x session-start.sh session-end.sh`

--- a/templates/agents/AGENTS.md
+++ b/templates/agents/AGENTS.md
@@ -34,6 +34,16 @@ Maintain a `MEMORY.md` file in your workspace to persist important details acros
 
 Read `MEMORY.md` at the start of each session if it exists. Update it when you learn something worth remembering. Keep it concise and organized — this is your long-term memory.
 
+## Task Memory (Beads)
+
+If this workspace has Beads configured (`.beads/` directory exists and `bd` is on PATH), use it for structured task tracking instead of `MEMORY.md`:
+
+- **Session start**: run `bd prime` to recover task context, then `bd ready --json` to see what to work on
+- **During work**: `bd create`, `bd update --claim`, `bd close` — see the `Beads Task Memory` skill for the full workflow
+- **Session end**: run `bd backup export-git` to snapshot progress to git
+
+Prefer `bd remember` over `MEMORY.md` for persistent knowledge when Beads is available. See `docs/beads.md` for setup instructions.
+
 ## Constraints
 
 - File system access is sandboxed to this workspace{{#allowPaths}} + additional folders listed above{{/allowPaths}}

--- a/templates/agents/AGENTS.md
+++ b/templates/agents/AGENTS.md
@@ -39,7 +39,7 @@ Read `MEMORY.md` at the start of each session if it exists. Update it when you l
 If this workspace has Beads configured (`.beads/` directory exists and `bd` is on PATH), use it for structured task tracking instead of `MEMORY.md`:
 
 - **Session start**: run `bd prime` to recover task context, then `bd ready --json` to see what to work on
-- **During work**: `bd create`, `bd update --claim`, `bd close` — see the `Beads Task Memory` skill for the full workflow
+- **During work**: `bd create`, `bd update --claim`, `bd close` — switch to the Beads agent (`/agent beads`) for the full workflow
 - **Session end**: run `bd backup export-git` to snapshot progress to git
 
 Prefer `bd remember` over `MEMORY.md` for persistent knowledge when Beads is available. See `docs/beads.md` for setup instructions.

--- a/templates/agents/beads.agent.md
+++ b/templates/agents/beads.agent.md
@@ -1,0 +1,101 @@
+---
+name: Beads Task Memory
+description: Persistent task tracking for this workspace using bd (Beads). Use this skill to create, track, and close tasks across sessions.
+---
+
+# Beads Task Memory Skill
+
+This workspace uses [Beads](https://github.com/steveyegge/beads) (`bd`) for persistent, structured task memory backed by [Dolt](https://github.com/dolthub/dolt). Tasks survive session restarts and can be shared across multiple bots via Dolt sync.
+
+## Prerequisites
+
+- `bd` CLI installed: `npm install -g @beads/bd` or `brew install beads`
+- `bd init --quiet --stealth` run in the workspace directory
+- `BEADS_DIR` and `BEADS_ACTOR` set in workspace `.env` (auto-injected by copilot-bridge)
+
+## Session Start Workflow
+
+Run at the beginning of every session to recover context:
+
+```bash
+bd prime              # Print workflow context and pending work
+bd ready --json       # List tasks with no open blockers (what to work on next)
+```
+
+## Task Operations
+
+### Creating tasks
+
+```bash
+bd create --title="Short descriptive title" --description="Why this exists and what done looks like" --type=task --priority=2
+```
+
+- Types: `task`, `feature`, `bug`, `epic`, `chore`, `decision`
+- Priority: `0` (critical) → `4` (backlog). Use numbers, not words.
+- For descriptions with special chars, pipe via stdin: `echo "description" | bd create --title="Title" --stdin`
+- **NEVER** use `bd edit` — it opens `$EDITOR` and blocks the agent.
+
+### Claiming and progressing work
+
+```bash
+bd update <id> --claim          # Atomically claim a task (sets assignee + in_progress)
+bd update <id> --status=done    # Update status without closing
+bd update <id> --notes="..."    # Add notes inline
+```
+
+### Closing tasks
+
+```bash
+bd close <id> --reason="What was done"
+bd close <id1> <id2> <id3>     # Close multiple at once
+```
+
+### Viewing and searching
+
+```bash
+bd show <id>                    # Full task details + audit trail
+bd list                         # All open issues
+bd list --status=in_progress    # Active work
+bd search "keyword"             # Full-text search
+bd stats                        # Project health summary
+```
+
+### Dependencies
+
+```bash
+bd dep add <child-id> <parent-id>   # child depends on parent (parent blocks child)
+bd blocked                          # Show all blocked issues
+```
+
+### Persistent knowledge
+
+```bash
+bd remember "key insight or decision"   # Store cross-session knowledge
+bd memories "keyword"                   # Search stored knowledge
+```
+
+## Session End Workflow
+
+Close completed tasks and back up before ending a session:
+
+```bash
+bd close <id1> <id2> ...    # Close all completed work
+bd backup export-git         # Snapshot to git branch (zero-infrastructure backup)
+```
+
+## When to Use Beads
+
+- Any task that spans multiple tool calls or may be interrupted mid-session
+- Multi-step work with subtasks (use epics + child tasks)
+- Decisions that should be recorded for future sessions
+- Anything you'd otherwise write to `MEMORY.md`
+
+When Beads is available, prefer `bd remember` over `MEMORY.md` for persistent knowledge — Beads is queryable, versioned, and concurrency-safe.
+
+## Troubleshooting
+
+```bash
+bd doctor          # Check Dolt server health
+bd dolt start      # Manually start Dolt server if needed
+bd dolt status     # Check server status
+```

--- a/templates/agents/beads.agent.md
+++ b/templates/agents/beads.agent.md
@@ -1,11 +1,18 @@
 ---
 name: Beads Task Memory
-description: Persistent task tracking for this workspace using bd (Beads). Use this skill to create, track, and close tasks across sessions.
+description: Persistent task tracking for this workspace using bd (Beads). Invoke with /agent beads to use this workflow for creating, tracking, and closing tasks across sessions.
 ---
 
-# Beads Task Memory Skill
+# Beads Task Memory
 
 This workspace uses [Beads](https://github.com/steveyegge/beads) (`bd`) for persistent, structured task memory backed by [Dolt](https://github.com/dolthub/dolt). Tasks survive session restarts and can be shared across multiple bots via Dolt sync.
+
+## How to use this agent
+
+Switch to this agent with `/agent beads` when you want to:
+- Recover task context at the start of a session (`bd prime`)
+- Create, update, claim, or close Beads tasks
+- Interpret `bd` output and decide what to work on next
 
 ## Prerequisites
 

--- a/templates/agents/beads.agent.md
+++ b/templates/agents/beads.agent.md
@@ -74,6 +74,16 @@ bd remember "key insight or decision"   # Store cross-session knowledge
 bd memories "keyword"                   # Search stored knowledge
 ```
 
+**Call `bd remember` at the moment of discovery — not at the end of the session.** Dolt commits immediately on every write, so memories survive any shutdown. Batching to the end risks losing them if the session is interrupted.
+
+Trigger `bd remember` whenever:
+- A non-obvious decision is made (e.g. "use X not Y because Z")
+- A gotcha, failure mode, or workaround is found
+- A config value or path turns out to be critical or surprising
+- Any fact that would take >5 minutes to re-discover next session
+
+Format: a concise, self-contained sentence — include the *why*, not just the *what*.
+
 ## Session End Workflow
 
 Close completed tasks and back up before ending a session:


### PR DESCRIPTION
Docs and config for Beads integration — no code changes. See #157 for the full journey, key decisions, and validation results.

## Changes

- `docs/beads.md` — setup guide, hook examples, 3-tier sync strategy, MCP alternative, troubleshooting
- `templates/agents/beads.agent.md` — agent skill file with complete `bd` workflow; includes point-of-discovery memory discipline (`bd remember` inline, not batched to session end)
- `templates/agents/AGENTS.md` — Beads section added; `MEMORY.md` kept as fallback
- `config.sample.json` — `shell(bd)` added to default permissions allow list

## No Breaking Changes

All additive. Workspaces without Beads are unaffected — conditional language throughout.

## Relationship to PR #158

Independent — can be reviewed and merged in either order. PR #158 wires the session hooks that the hook examples here depend on.

Relates to: #157