### PR TITLE
refactor: make all store functions async

### DIFF
--- a/scripts/test-admin-api.ts
+++ b/scripts/test-admin-api.ts
@@ -79,7 +79,7 @@ async function main() {
 
   // --- Test 6: Dynamic channel SQLite CRUD ---
   console.log('6. Dynamic channel persistence');
-  addDynamicChannel({
+  await addDynamicChannel({
     channelId,
     platform: platformName,
     name: TEST_CHANNEL_NAME,
@@ -87,13 +87,13 @@ async function main() {
     workingDirectory: '/tmp/test-workspace',
     isDM: false,
   });
-  const stored = getDynamicChannel(channelId);
+  const stored = await getDynamicChannel(channelId);
   if (!stored) throw new Error('Dynamic channel not found in SQLite');
   console.log(`   Stored: ${stored.channelId} → ${stored.workingDirectory}`);
-  const all = getDynamicChannels();
+  const all = await getDynamicChannels();
   console.log(`   Total dynamic channels: ${all.length}`);
-  removeDynamicChannel(channelId);
-  const afterRemove = getDynamicChannel(channelId);
+  await removeDynamicChannel(channelId);
+  const afterRemove = await getDynamicChannel(channelId);
   if (afterRemove) throw new Error('Dynamic channel still exists after removal');
   console.log(`   Removed: confirmed\n`);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -530,13 +530,13 @@ export function getInterAgentConfig(): InterAgentConfig {
   return config.interAgent ?? { enabled: false };
 }
 
-export function getChannelConfig(channelId: string): ChannelConfig & { permissionMode: string } {
+export async function getChannelConfig(channelId: string): Promise<ChannelConfig & { permissionMode: string }> {
   const config = getConfig();
   let channel = config.channels.find(c => c.id === channelId);
 
   // Fall back to dynamic channels from SQLite
   if (!channel) {
-    const dyn = getDynamicChannel(channelId);
+    const dyn = await getDynamicChannel(channelId);
     if (dyn) {
       channel = {
         id: dyn.channelId,
@@ -557,7 +557,7 @@ export function getChannelConfig(channelId: string): ChannelConfig & { permissio
   if (!channel) throw new Error(`No config found for channel "${channelId}"`);
   
   // Resolve agent: channel-level overrides bot-level default
-  const botConfig = getChannelBotConfig(channelId);
+  const botConfig = await getChannelBotConfig(channelId);
   const resolvedAgent = channel.agent !== undefined ? channel.agent
     : botConfig?.agent !== undefined ? botConfig.agent
     : config.defaults.agent;
@@ -574,10 +574,10 @@ export function getChannelConfig(channelId: string): ChannelConfig & { permissio
 }
 
 /** Check if a channel ID is in our configured channels list (static or dynamic) */
-export function isConfiguredChannel(channelId: string): boolean {
+export async function isConfiguredChannel(channelId: string): Promise<boolean> {
   const config = getConfig();
   if (config.channels.some(c => c.id === channelId)) return true;
-  return getDynamicChannel(channelId) !== null;
+  return (await getDynamicChannel(channelId)) !== null;
 }
 
 /**
@@ -605,13 +605,13 @@ export function markChannelAsDM(channelId: string): void {
  * Get the resolved bot token for a channel.
  * Supports both single-bot (botToken) and multi-bot (bots map) configs.
  */
-export function getChannelBotToken(channelId: string): string {
+export async function getChannelBotToken(channelId: string): Promise<string> {
   const config = getConfig();
   let channel: { platform: string; bot?: string } | undefined = config.channels.find(c => c.id === channelId);
 
   // Fall back to dynamic channels
   if (!channel) {
-    const dyn = getDynamicChannel(channelId);
+    const dyn = await getDynamicChannel(channelId);
     if (dyn) channel = { platform: dyn.platform, bot: dyn.bot };
   }
 
@@ -631,12 +631,12 @@ export function getChannelBotToken(channelId: string): string {
 }
 
 /** Get the BotConfig for a channel (if multi-bot). */
-export function getChannelBotConfig(channelId: string): BotConfig | null {
+export async function getChannelBotConfig(channelId: string): Promise<BotConfig | null> {
   const config = getConfig();
   let channel: { platform: string; bot?: string } | undefined = config.channels.find(c => c.id === channelId);
 
   if (!channel) {
-    const dyn = getDynamicChannel(channelId);
+    const dyn = await getDynamicChannel(channelId);
     if (dyn) channel = { platform: dyn.platform, bot: dyn.bot };
   }
 
@@ -704,12 +704,12 @@ export function getAdminBotName(platformName: string): string | null {
 }
 
 /** Get the bot name a channel uses. */
-export function getChannelBotName(channelId: string): string {
+export async function getChannelBotName(channelId: string): Promise<string> {
   const config = getConfig();
   let channel: { platform: string; bot?: string } | undefined = config.channels.find(c => c.id === channelId);
 
   if (!channel) {
-    const dyn = getDynamicChannel(channelId);
+    const dyn = await getDynamicChannel(channelId);
     if (dyn) channel = { platform: dyn.platform, bot: dyn.bot };
   }
 

--- a/src/core/byok-model-ux.test.ts
+++ b/src/core/byok-model-ux.test.ts
@@ -136,27 +136,27 @@ describe('/model command listing', () => {
     },
   };
 
-  it('groups models by provider in listing', () => {
-    const result = handleCommand(channelId, '/model', sessionInfo, prefs, meta, allModels, undefined, null, providers);
+  it('groups models by provider in listing', async () => {
+    const result = await handleCommand(channelId, '/model', sessionInfo, prefs, meta, allModels, undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('GitHub Copilot');
     expect(result.response).toContain('ollama-local');
   });
 
-  it('shows current model indicator for Copilot model', () => {
-    const result = handleCommand(channelId, '/model', sessionInfo, prefs, meta, allModels, undefined, null, providers);
+  it('shows current model indicator for Copilot model', async () => {
+    const result = await handleCommand(channelId, '/model', sessionInfo, prefs, meta, allModels, undefined, null, providers);
     expect(result.response).toContain('← current');
   });
 
-  it('filters by provider name', () => {
-    const result = handleCommand(channelId, '/model ollama-local', sessionInfo, prefs, meta, allModels, undefined, null, providers);
+  it('filters by provider name', async () => {
+    const result = await handleCommand(channelId, '/model ollama-local', sessionInfo, prefs, meta, allModels, undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('qwen3:8b');
     expect(result.response).not.toContain('claude-sonnet');
   });
 
-  it('hides Billing column for BYOK provider sections', () => {
-    const result = handleCommand(channelId, '/model', sessionInfo, prefs, meta, allModels, undefined, null, providers);
+  it('hides Billing column for BYOK provider sections', async () => {
+    const result = await handleCommand(channelId, '/model', sessionInfo, prefs, meta, allModels, undefined, null, providers);
     // Copilot section should have Billing in table header
     const sections = result.response!.split('**ollama-local**');
     expect(sections[0]).toContain('| Model | Billing |');
@@ -165,13 +165,13 @@ describe('/model command listing', () => {
     expect(byokTable).not.toContain('Billing');
   });
 
-  it('hides Billing column when filtering to BYOK provider', () => {
-    const result = handleCommand(channelId, '/model ollama-local', sessionInfo, prefs, meta, allModels, undefined, null, providers);
+  it('hides Billing column when filtering to BYOK provider', async () => {
+    const result = await handleCommand(channelId, '/model ollama-local', sessionInfo, prefs, meta, allModels, undefined, null, providers);
     expect(result.response).not.toContain('Billing');
   });
 
-  it('shows no-provider listing without providers', () => {
-    const result = handleCommand(channelId, '/model', sessionInfo, prefs, meta, copilotModels);
+  it('shows no-provider listing without providers', async () => {
+    const result = await handleCommand(channelId, '/model', sessionInfo, prefs, meta, copilotModels);
     expect(result.handled).toBe(true);
     expect(result.response).not.toContain('GitHub Copilot'); // no grouping without providers
     expect(result.response).toContain('claude-sonnet-4.6');
@@ -196,37 +196,37 @@ describe('/model switch (provider-aware)', () => {
     },
   };
 
-  it('returns provider in payload for BYOK model switch', () => {
-    const result = handleCommand(channelId, '/model ollama-local:qwen3:8b', sessionInfo, prefs, meta, allModels, undefined, null, providers);
+  it('returns provider in payload for BYOK model switch', async () => {
+    const result = await handleCommand(channelId, '/model ollama-local:qwen3:8b', sessionInfo, prefs, meta, allModels, undefined, null, providers);
     expect(result.action).toBe('switch_model');
     expect(result.payload).toEqual({ modelId: 'qwen3:8b', provider: 'ollama-local' });
   });
 
-  it('returns null provider for Copilot model switch', () => {
-    const result = handleCommand(channelId, '/model gpt-5.4', sessionInfo, prefs, meta, allModels, undefined, null, providers);
+  it('returns null provider for Copilot model switch', async () => {
+    const result = await handleCommand(channelId, '/model gpt-5.4', sessionInfo, prefs, meta, allModels, undefined, null, providers);
     expect(result.action).toBe('switch_model');
     expect(result.payload).toEqual({ modelId: 'gpt-5.4', provider: null });
   });
 
-  it('returns bare model ID (not prefixed) in payload', () => {
-    const result = handleCommand(channelId, '/model azure-prod:gpt-5', sessionInfo, prefs, meta, allModels, undefined, null, providers);
+  it('returns bare model ID (not prefixed) in payload', async () => {
+    const result = await handleCommand(channelId, '/model azure-prod:gpt-5', sessionInfo, prefs, meta, allModels, undefined, null, providers);
     expect(result.payload).toEqual({ modelId: 'gpt-5', provider: 'azure-prod' });
   });
 
-  it('resolves bare BYOK model name to correct provider', () => {
-    const result = handleCommand(channelId, '/model qwen3:8b', sessionInfo, prefs, meta, allModels, undefined, null, providers);
+  it('resolves bare BYOK model name to correct provider', async () => {
+    const result = await handleCommand(channelId, '/model qwen3:8b', sessionInfo, prefs, meta, allModels, undefined, null, providers);
     expect(result.action).toBe('switch_model');
     expect(result.payload).toEqual({ modelId: 'qwen3:8b', provider: 'ollama-local' });
   });
 
-  it('returns structured payload even when models list unavailable', () => {
-    const result = handleCommand(channelId, '/model some-model', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('returns structured payload even when models list unavailable', async () => {
+    const result = await handleCommand(channelId, '/model some-model', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.action).toBe('switch_model');
     expect(result.payload).toEqual({ modelId: 'some-model', provider: null });
   });
 
-  it('parses provider prefix when models list unavailable', () => {
-    const result = handleCommand(channelId, '/model ollama-local:qwen3:8b', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('parses provider prefix when models list unavailable', async () => {
+    const result = await handleCommand(channelId, '/model ollama-local:qwen3:8b', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.action).toBe('switch_model');
     expect(result.payload).toEqual({ modelId: 'qwen3:8b', provider: 'ollama-local' });
   });

--- a/src/core/byok-onboarding.test.ts
+++ b/src/core/byok-onboarding.test.ts
@@ -32,8 +32,8 @@ const providers = {
 // --- /provider list ---
 
 describe('/provider command', () => {
-  it('lists configured providers', () => {
-    const result = handleCommand(channelId, '/provider', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('lists configured providers', async () => {
+    const result = await handleCommand(channelId, '/provider', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('ollama-local');
     expect(result.response).toContain('azure-prod');
@@ -41,21 +41,21 @@ describe('/provider command', () => {
     expect(result.response).toContain('qwen3:8b');
   });
 
-  it('shows helpful message when no providers configured', () => {
-    const result = handleCommand(channelId, '/provider', sessionInfo, prefs, meta, []);
+  it('shows helpful message when no providers configured', async () => {
+    const result = await handleCommand(channelId, '/provider', sessionInfo, prefs, meta, []);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('No BYOK providers');
     expect(result.response).toContain('config.json');
   });
 
-  it('/providers alias works', () => {
-    const result = handleCommand(channelId, '/providers', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('/providers alias works', async () => {
+    const result = await handleCommand(channelId, '/providers', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('ollama-local');
   });
 
-  it('shows auth method in provider listing', () => {
-    const result = handleCommand(channelId, '/provider', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('shows auth method in provider listing', async () => {
+    const result = await handleCommand(channelId, '/provider', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.response).toContain('apiKeyEnv: AZURE_KEY');
     expect(result.response).toContain('none'); // ollama has no auth
   });
@@ -64,22 +64,22 @@ describe('/provider command', () => {
 // --- /provider test ---
 
 describe('/provider test', () => {
-  it('returns provider_test action for known provider', () => {
-    const result = handleCommand(channelId, '/provider test ollama-local', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('returns provider_test action for known provider', async () => {
+    const result = await handleCommand(channelId, '/provider test ollama-local', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.action).toBe('provider_test');
     expect(result.payload).toBe('ollama-local');
   });
 
-  it('returns error for unknown provider', () => {
-    const result = handleCommand(channelId, '/provider test nonexistent', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('returns error for unknown provider', async () => {
+    const result = await handleCommand(channelId, '/provider test nonexistent', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('Unknown provider');
     expect(result.action).toBeUndefined();
   });
 
-  it('is case-insensitive on provider name', () => {
-    const result = handleCommand(channelId, '/provider test OLLAMA-LOCAL', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('is case-insensitive on provider name', async () => {
+    const result = await handleCommand(channelId, '/provider test OLLAMA-LOCAL', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.action).toBe('provider_test');
     expect(result.payload).toBe('ollama-local');
   });
@@ -88,29 +88,29 @@ describe('/provider test', () => {
 // --- /provider add|remove guidance ---
 
 describe('/provider add|remove', () => {
-  it('guides non-admin user to config.json for add', () => {
-    const result = handleCommand(channelId, '/provider add ollama', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('guides non-admin user to config.json for add', async () => {
+    const result = await handleCommand(channelId, '/provider add ollama', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('config.json');
     expect(result.response).toContain('/reload config');
   });
 
-  it('offers to help when bot is admin', () => {
+  it('offers to help when bot is admin', async () => {
     const adminMeta = { workingDirectory: '/tmp', bot: 'admin' };
-    const result = handleCommand(channelId, '/provider add ollama', sessionInfo, prefs, adminMeta, [], undefined, null, providers);
+    const result = await handleCommand(channelId, '/provider add ollama', sessionInfo, prefs, adminMeta, [], undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('I can help');
     expect(result.response).not.toContain('Ask the');
   });
 
-  it('guides user to config.json for remove', () => {
-    const result = handleCommand(channelId, '/provider remove azure-prod', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('guides user to config.json for remove', async () => {
+    const result = await handleCommand(channelId, '/provider remove azure-prod', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('config.json');
   });
 
-  it('guides user to config.json for delete', () => {
-    const result = handleCommand(channelId, '/provider delete azure-prod', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('guides user to config.json for delete', async () => {
+    const result = await handleCommand(channelId, '/provider delete azure-prod', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('config.json');
   });
@@ -119,8 +119,8 @@ describe('/provider add|remove', () => {
 // --- /provider unknown subcommand ---
 
 describe('/provider unknown subcommand', () => {
-  it('shows usage for unknown subcommand', () => {
-    const result = handleCommand(channelId, '/provider foo', sessionInfo, prefs, meta, [], undefined, null, providers);
+  it('shows usage for unknown subcommand', async () => {
+    const result = await handleCommand(channelId, '/provider foo', sessionInfo, prefs, meta, [], undefined, null, providers);
     expect(result.handled).toBe(true);
     expect(result.response).toContain('Unknown subcommand');
     expect(result.response).toContain('/provider test');

--- a/src/core/byok-providers.test.ts
+++ b/src/core/byok-providers.test.ts
@@ -485,37 +485,37 @@ describe('channel prefs provider field', () => {
     store = await import('../state/store.js');
   });
 
-  it('stores and retrieves provider in channel prefs', () => {
+  it('stores and retrieves provider in channel prefs', async () => {
     const testChannel = `byok-test-${Date.now()}`;
-    store.setChannelPrefs(testChannel, { model: 'qwen3:8b', provider: 'ollama' });
-    const prefs = store.getChannelPrefs(testChannel);
+    await store.setChannelPrefs(testChannel, { model: 'qwen3:8b', provider: 'ollama' });
+    const prefs = await store.getChannelPrefs(testChannel);
     expect(prefs).not.toBeNull();
     expect(prefs!.provider).toBe('ollama');
     expect(prefs!.model).toBe('qwen3:8b');
   });
 
-  it('returns null provider when not set', () => {
+  it('returns null provider when not set', async () => {
     const testChannel = `byok-test-${Date.now()}-noprov`;
-    store.setChannelPrefs(testChannel, { model: 'claude-sonnet-4.6' });
-    const prefs = store.getChannelPrefs(testChannel);
+    await store.setChannelPrefs(testChannel, { model: 'claude-sonnet-4.6' });
+    const prefs = await store.getChannelPrefs(testChannel);
     expect(prefs).not.toBeNull();
     expect(prefs!.provider).toBeNull();
   });
 
-  it('updates provider on existing prefs', () => {
+  it('updates provider on existing prefs', async () => {
     const testChannel = `byok-test-${Date.now()}-update`;
-    store.setChannelPrefs(testChannel, { model: 'claude-sonnet-4.6' });
-    store.setChannelPrefs(testChannel, { provider: 'ollama' });
-    const prefs = store.getChannelPrefs(testChannel);
+    await store.setChannelPrefs(testChannel, { model: 'claude-sonnet-4.6' });
+    await store.setChannelPrefs(testChannel, { provider: 'ollama' });
+    const prefs = await store.getChannelPrefs(testChannel);
     expect(prefs!.provider).toBe('ollama');
     expect(prefs!.model).toBe('claude-sonnet-4.6');
   });
 
-  it('clears provider by setting to null', () => {
+  it('clears provider by setting to null', async () => {
     const testChannel = `byok-test-${Date.now()}-clear`;
-    store.setChannelPrefs(testChannel, { provider: 'ollama' });
-    store.setChannelPrefs(testChannel, { provider: null });
-    const prefs = store.getChannelPrefs(testChannel);
+    await store.setChannelPrefs(testChannel, { provider: 'ollama' });
+    await store.setChannelPrefs(testChannel, { provider: null });
+    const prefs = await store.getChannelPrefs(testChannel);
     expect(prefs!.provider).toBeNull();
   });
 });

--- a/src/core/command-handler.test.ts
+++ b/src/core/command-handler.test.ts
@@ -31,28 +31,28 @@ describe('parseCommand', () => {
 // --- /reload subcommands ---
 
 describe('/reload subcommands', () => {
-  it('/reload returns reload_session', () => {
-    const result = handleCommand('ch1', '/reload');
+  it('/reload returns reload_session', async () => {
+    const result = await handleCommand('ch1', '/reload');
     expect(result.action).toBe('reload_session');
   });
 
-  it('/reload config returns reload_config', () => {
-    const result = handleCommand('ch1', '/reload config');
+  it('/reload config returns reload_config', async () => {
+    const result = await handleCommand('ch1', '/reload config');
     expect(result.action).toBe('reload_config');
   });
 
-  it('/reload mcp returns reload_mcp', () => {
-    const result = handleCommand('ch1', '/reload mcp');
+  it('/reload mcp returns reload_mcp', async () => {
+    const result = await handleCommand('ch1', '/reload mcp');
     expect(result.action).toBe('reload_mcp');
   });
 
-  it('/reload skills returns reload_skills', () => {
-    const result = handleCommand('ch1', '/reload skills');
+  it('/reload skills returns reload_skills', async () => {
+    const result = await handleCommand('ch1', '/reload skills');
     expect(result.action).toBe('reload_skills');
   });
 
-  it('/reload MCP is case-insensitive', () => {
-    const result = handleCommand('ch1', '/reload MCP');
+  it('/reload MCP is case-insensitive', async () => {
+    const result = await handleCommand('ch1', '/reload MCP');
     expect(result.action).toBe('reload_mcp');
   });
 });
@@ -78,24 +78,24 @@ describe('/agent command', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('deselects agent when no args', () => {
-    const result = handleCommand('ch-1', '/agent');
+  it('deselects agent when no args', async () => {
+    const result = await handleCommand('ch-1', '/agent');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('switch_agent');
     expect(result.payload).toBeNull();
     expect(result.response).toContain('deselected');
   });
 
-  it('switches to valid agent', () => {
-    const result = handleCommand('ch-1', '/agent network', undefined, undefined, { workingDirectory: tmpDir });
+  it('switches to valid agent', async () => {
+    const result = await handleCommand('ch-1', '/agent network', undefined, undefined, { workingDirectory: tmpDir });
     expect(result.handled).toBe(true);
     expect(result.action).toBe('switch_agent');
     expect(result.payload).toBe('network');
     expect(result.response).toContain('network');
   });
 
-  it('rejects invalid agent with suggestions', () => {
-    const result = handleCommand('ch-1', '/agent nonexistent', undefined, undefined, { workingDirectory: tmpDir });
+  it('rejects invalid agent with suggestions', async () => {
+    const result = await handleCommand('ch-1', '/agent nonexistent', undefined, undefined, { workingDirectory: tmpDir });
     expect(result.handled).toBe(true);
     expect(result.action).toBeUndefined();
     expect(result.response).toContain('not found');
@@ -103,10 +103,10 @@ describe('/agent command', () => {
     expect(result.response).toContain('hvac');
   });
 
-  it('rejects invalid agent when no agents exist', () => {
+  it('rejects invalid agent when no agents exist', async () => {
     const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmd-test-empty-'));
     try {
-      const result = handleCommand('ch-1', '/agent nonexistent', undefined, undefined, { workingDirectory: emptyDir });
+      const result = await handleCommand('ch-1', '/agent nonexistent', undefined, undefined, { workingDirectory: emptyDir });
       expect(result.handled).toBe(true);
       expect(result.response).toContain('not found');
       expect(result.response).toContain('No agent definitions found');
@@ -115,8 +115,8 @@ describe('/agent command', () => {
     }
   });
 
-  it('falls through without validation when no workingDirectory', () => {
-    const result = handleCommand('ch-1', '/agent anything', undefined, undefined, {});
+  it('falls through without validation when no workingDirectory', async () => {
+    const result = await handleCommand('ch-1', '/agent anything', undefined, undefined, {});
     expect(result.handled).toBe(true);
     expect(result.action).toBe('switch_agent');
     expect(result.payload).toBe('anything');
@@ -144,30 +144,30 @@ describe('/agents command', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('lists available agents', () => {
-    const result = handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: tmpDir });
+  it('lists available agents', async () => {
+    const result = await handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: tmpDir });
     expect(result.handled).toBe(true);
     expect(result.response).toContain('Available Agents');
     expect(result.response).toContain('network');
     expect(result.response).toContain('hvac');
   });
 
-  it('shows current agent indicator', () => {
-    const result = handleCommand('ch-1', '/agents', { sessionId: 's1', model: 'm1', agent: 'network' }, undefined, { workingDirectory: tmpDir });
+  it('shows current agent indicator', async () => {
+    const result = await handleCommand('ch-1', '/agents', { sessionId: 's1', model: 'm1', agent: 'network' }, undefined, { workingDirectory: tmpDir });
     expect(result.response).toContain('← current');
     expect(result.response).toContain('network');
   });
 
-  it('warns when current agent has no definition', () => {
-    const result = handleCommand('ch-1', '/agents', { sessionId: 's1', model: 'm1', agent: 'deleted' }, undefined, { workingDirectory: tmpDir });
+  it('warns when current agent has no definition', async () => {
+    const result = await handleCommand('ch-1', '/agents', { sessionId: 's1', model: 'm1', agent: 'deleted' }, undefined, { workingDirectory: tmpDir });
     expect(result.response).toContain('deleted');
     expect(result.response).toContain('no definition file');
   });
 
-  it('shows empty state when no agents exist', () => {
+  it('shows empty state when no agents exist', async () => {
     const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmd-test-empty-'));
     try {
-      const result = handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: emptyDir });
+      const result = await handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: emptyDir });
       expect(result.response).toContain('No agent definitions found');
       expect(result.response).toContain('.agent.md');
     } finally {
@@ -175,17 +175,17 @@ describe('/agents command', () => {
     }
   });
 
-  it('reports no workspace when workingDirectory missing', () => {
-    const result = handleCommand('ch-1', '/agents', undefined, undefined, {});
+  it('reports no workspace when workingDirectory missing', async () => {
+    const result = await handleCommand('ch-1', '/agents', undefined, undefined, {});
     expect(result.response).toContain('No workspace configured');
   });
 
-  it('extracts description from agent content', () => {
-    const result = handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: tmpDir });
+  it('extracts description from agent content', async () => {
+    const result = await handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: tmpDir });
     expect(result.response).toContain('Handles network queries');
   });
 
-  it('skips indented headings when extracting description', () => {
+  it('skips indented headings when extracting description', async () => {
     const indentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmd-test-indent-'));
     const savedHome = process.env.HOME;
     process.env.HOME = indentDir;
@@ -193,7 +193,7 @@ describe('/agents command', () => {
       const agentsDir = path.join(indentDir, 'agents');
       fs.mkdirSync(agentsDir);
       fs.writeFileSync(path.join(agentsDir, 'test.agent.md'), '  # Indented Heading\nActual description line.');
-      const result = handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: indentDir });
+      const result = await handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: indentDir });
       expect(result.response).toContain('Actual description line');
       expect(result.response).not.toContain('Indented Heading');
     } finally {
@@ -202,7 +202,7 @@ describe('/agents command', () => {
     }
   });
 
-  it('extracts description from YAML frontmatter', () => {
+  it('extracts description from YAML frontmatter', async () => {
     const fmDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmd-test-fm-'));
     const savedHome = process.env.HOME;
     process.env.HOME = fmDir;
@@ -210,7 +210,7 @@ describe('/agents command', () => {
       const agentsDir = path.join(fmDir, 'agents');
       fs.mkdirSync(agentsDir);
       fs.writeFileSync(path.join(agentsDir, 'fancy.agent.md'), '---\nname: fancy\ndescription: A very fancy agent.\n---\n# Fancy Agent');
-      const result = handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: fmDir });
+      const result = await handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: fmDir });
       expect(result.response).toContain('A very fancy agent');
       expect(result.response).not.toContain('---');
     } finally {
@@ -219,7 +219,7 @@ describe('/agents command', () => {
     }
   });
 
-  it('parses YAML block scalar descriptions', () => {
+  it('parses YAML block scalar descriptions', async () => {
     const fmDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmd-block-'));
     const savedHome = process.env.HOME;
     process.env.HOME = fmDir;
@@ -228,7 +228,7 @@ describe('/agents command', () => {
       fs.mkdirSync(agentsDir);
       fs.writeFileSync(path.join(agentsDir, 'bob.agent.md'),
         '---\nname: Bob\ndescription: >-\n  Use this agent for work prioritization\n  and meeting prep.\n---\n# Bob');
-      const result = handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: fmDir });
+      const result = await handleCommand('ch-1', '/agents', undefined, undefined, { workingDirectory: fmDir });
       expect(result.response).toContain('Use this agent for work prioritization and meeting prep.');
     } finally {
       if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
@@ -240,55 +240,55 @@ describe('/agents command', () => {
 // --- Mode commands ---
 
 describe('mode commands', () => {
-  it('/plan returns action plan with no payload when bare', () => {
-    const result = handleCommand('ch-mode-1', '/plan');
+  it('/plan returns action plan with no payload when bare', async () => {
+    const result = await handleCommand('ch-mode-1', '/plan');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('plan');
     expect(result.payload).toBeUndefined();
   });
 
-  it('/plan show returns action plan with show payload', () => {
-    const result = handleCommand('ch-mode-1', '/plan show');
+  it('/plan show returns action plan with show payload', async () => {
+    const result = await handleCommand('ch-mode-1', '/plan show');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('plan');
     expect(result.payload).toBe('show');
   });
 
-  it('/plan clear returns action plan with clear payload', () => {
-    const result = handleCommand('ch-mode-1', '/plan clear');
+  it('/plan clear returns action plan with clear payload', async () => {
+    const result = await handleCommand('ch-mode-1', '/plan clear');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('plan');
     expect(result.payload).toBe('clear');
   });
 
-  it('/plan on returns action plan with on payload', () => {
-    const result = handleCommand('ch-mode-1', '/plan on');
+  it('/plan on returns action plan with on payload', async () => {
+    const result = await handleCommand('ch-mode-1', '/plan on');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('plan');
     expect(result.payload).toBe('on');
   });
 
-  it('/plan off returns action plan with off payload', () => {
-    const result = handleCommand('ch-mode-1', '/plan off');
+  it('/plan off returns action plan with off payload', async () => {
+    const result = await handleCommand('ch-mode-1', '/plan off');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('plan');
     expect(result.payload).toBe('off');
   });
 
-  it('/autopilot returns action toggle_autopilot', () => {
-    const result = handleCommand('ch-mode-1', '/autopilot');
+  it('/autopilot returns action toggle_autopilot', async () => {
+    const result = await handleCommand('ch-mode-1', '/autopilot');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('toggle_autopilot');
   });
 
-  it('/yolo toggles permissionMode to autopilot', () => {
-    const result = handleCommand('ch-mode-yolo', '/yolo', undefined, { verbose: false, permissionMode: 'interactive', reasoningEffort: null });
+  it('/yolo toggles permissionMode to autopilot', async () => {
+    const result = await handleCommand('ch-mode-yolo', '/yolo', undefined, { verbose: false, permissionMode: 'interactive', reasoningEffort: null });
     expect(result.handled).toBe(true);
     expect(result.response).toContain('Yolo enabled');
   });
 
-  it('/yolo toggles permissionMode back to interactive', () => {
-    const result = handleCommand('ch-mode-yolo', '/yolo', undefined, { verbose: false, permissionMode: 'autopilot', reasoningEffort: null });
+  it('/yolo toggles permissionMode back to interactive', async () => {
+    const result = await handleCommand('ch-mode-yolo', '/yolo', undefined, { verbose: false, permissionMode: 'autopilot', reasoningEffort: null });
     expect(result.handled).toBe(true);
     expect(result.response).toContain('Yolo disabled');
   });
@@ -297,8 +297,8 @@ describe('mode commands', () => {
 // --- /status mode display ---
 
 describe('/status command', () => {
-  it('shows interactive mode by default', () => {
-    const result = handleCommand('ch-status-1', '/status',
+  it('shows interactive mode by default', async () => {
+    const result = await handleCommand('ch-status-1', '/status',
       { sessionId: 'abc-123', model: 'claude-sonnet-4.5', agent: null },
       { verbose: false, permissionMode: 'interactive', reasoningEffort: null },
     );
@@ -308,9 +308,9 @@ describe('/status command', () => {
 
   it('shows plan mode when sessionMode is plan', async () => {
     const { setChannelPrefs } = await import('../state/store.js');
-    setChannelPrefs('ch-status-plan', { sessionMode: 'plan', permissionMode: 'autopilot' });
+    await setChannelPrefs('ch-status-plan', { sessionMode: 'plan', permissionMode: 'autopilot' });
 
-    const result = handleCommand('ch-status-plan', '/status',
+    const result = await handleCommand('ch-status-plan', '/status',
       { sessionId: 'abc-123', model: 'claude-sonnet-4.5', agent: null },
       { verbose: false, permissionMode: 'autopilot', reasoningEffort: null },
     );
@@ -320,9 +320,9 @@ describe('/status command', () => {
 
   it('shows autopilot mode when sessionMode is autopilot', async () => {
     const { setChannelPrefs } = await import('../state/store.js');
-    setChannelPrefs('ch-status-auto', { sessionMode: 'autopilot' });
+    await setChannelPrefs('ch-status-auto', { sessionMode: 'autopilot' });
 
-    const result = handleCommand('ch-status-auto', '/status',
+    const result = await handleCommand('ch-status-auto', '/status',
       { sessionId: 'abc-123', model: 'claude-sonnet-4.5', agent: null },
       { verbose: false, permissionMode: 'interactive', reasoningEffort: null },
     );
@@ -330,8 +330,8 @@ describe('/status command', () => {
     expect(result.response).toContain('Yolo: 🛡️ Off');
   });
 
-  it('shows no active session when no sessionInfo', () => {
-    const result = handleCommand('ch-status-none', '/status');
+  it('shows no active session when no sessionInfo', async () => {
+    const result = await handleCommand('ch-status-none', '/status');
     expect(result.response).toContain('No active session');
   });
 });
@@ -342,8 +342,8 @@ describe('/context command', () => {
   const SESSION_INFO = { sessionId: 'sess-ctx', model: 'claude-opus-4.6', agent: null };
   const PREFS = { verbose: false, permissionMode: 'interactive' as const, reasoningEffort: null };
 
-  it('shows tokenLimit when contextWindowTokens is absent', () => {
-    const result = handleCommand('ch-ctx-1', '/context', SESSION_INFO, PREFS, undefined, undefined, undefined,
+  it('shows tokenLimit when contextWindowTokens is absent', async () => {
+    const result = await handleCommand('ch-ctx-1', '/context', SESSION_INFO, PREFS, undefined, undefined, undefined,
       { currentTokens: 50000, tokenLimit: 168000 },
     );
     expect(result.handled).toBe(true);
@@ -351,8 +351,8 @@ describe('/context command', () => {
     expect(result.response).toContain('50k');
   });
 
-  it('prefers contextWindowTokens over tokenLimit', () => {
-    const result = handleCommand('ch-ctx-2', '/context', SESSION_INFO, PREFS, undefined, undefined, undefined,
+  it('prefers contextWindowTokens over tokenLimit', async () => {
+    const result = await handleCommand('ch-ctx-2', '/context', SESSION_INFO, PREFS, undefined, undefined, undefined,
       { currentTokens: 50000, tokenLimit: 168000, contextWindowTokens: 200000 },
     );
     expect(result.handled).toBe(true);
@@ -360,16 +360,16 @@ describe('/context command', () => {
     expect(result.response).not.toContain('168k');
   });
 
-  it('calculates percentage against contextWindowTokens', () => {
-    const result = handleCommand('ch-ctx-3', '/context', SESSION_INFO, PREFS, undefined, undefined, undefined,
+  it('calculates percentage against contextWindowTokens', async () => {
+    const result = await handleCommand('ch-ctx-3', '/context', SESSION_INFO, PREFS, undefined, undefined, undefined,
       { currentTokens: 100000, tokenLimit: 168000, contextWindowTokens: 200000 },
     );
     // 100k / 200k = 50%
     expect(result.response).toContain('50%');
   });
 
-  it('falls back to tokenLimit when contextWindowTokens is undefined', () => {
-    const result = handleCommand('ch-ctx-4', '/context', SESSION_INFO, PREFS, undefined, undefined, undefined,
+  it('falls back to tokenLimit when contextWindowTokens is undefined', async () => {
+    const result = await handleCommand('ch-ctx-4', '/context', SESSION_INFO, PREFS, undefined, undefined, undefined,
       { currentTokens: 84000, tokenLimit: 168000, contextWindowTokens: undefined },
     );
     // 84k / 168k = 50%
@@ -377,8 +377,8 @@ describe('/context command', () => {
     expect(result.response).toContain('50%');
   });
 
-  it('shows context in /status when usage is available', () => {
-    const result = handleCommand('ch-ctx-5', '/status', SESSION_INFO, PREFS, undefined, undefined, undefined,
+  it('shows context in /status when usage is available', async () => {
+    const result = await handleCommand('ch-ctx-5', '/status', SESSION_INFO, PREFS, undefined, undefined, undefined,
       { currentTokens: 50000, tokenLimit: 168000, contextWindowTokens: 200000 },
     );
     expect(result.response).toContain('200k');
@@ -395,8 +395,8 @@ describe('/reasoning command', () => {
     defaultReasoningEffort: 'medium',
   };
 
-  it('returns set_reasoning action with valid level', () => {
-    const result = handleCommand('ch-reason-1', '/reasoning high', SESSION_INFO,
+  it('returns set_reasoning action with valid level', async () => {
+    const result = await handleCommand('ch-reason-1', '/reasoning high', SESSION_INFO,
       { verbose: false, permissionMode: 'interactive', reasoningEffort: null },
       undefined, [REASONING_MODEL]);
     expect(result.handled).toBe(true);
@@ -404,8 +404,8 @@ describe('/reasoning command', () => {
     expect(result.payload).toBe('high');
   });
 
-  it('rejects invalid reasoning level', () => {
-    const result = handleCommand('ch-reason-2', '/reasoning banana', SESSION_INFO,
+  it('rejects invalid reasoning level', async () => {
+    const result = await handleCommand('ch-reason-2', '/reasoning banana', SESSION_INFO,
       { verbose: false, permissionMode: 'interactive', reasoningEffort: null },
       undefined, [REASONING_MODEL]);
     expect(result.handled).toBe(true);
@@ -413,8 +413,8 @@ describe('/reasoning command', () => {
     expect(result.response).toContain('Invalid reasoning effort');
   });
 
-  it('shows current level when no args', () => {
-    const result = handleCommand('ch-reason-3', '/reasoning', SESSION_INFO,
+  it('shows current level when no args', async () => {
+    const result = await handleCommand('ch-reason-3', '/reasoning', SESSION_INFO,
       { verbose: false, permissionMode: 'interactive', reasoningEffort: 'high' });
     expect(result.handled).toBe(true);
     expect(result.response).toContain('Current reasoning effort: **high**');
@@ -441,9 +441,9 @@ describe('BYOK reasoning effort suppression', () => {
 
   it('/status suppresses reasoning effort when BYOK provider is active', async () => {
     const { setChannelPrefs } = await import('../state/store.js');
-    setChannelPrefs('ch-byok-status', { provider: 'azure' });
+    await setChannelPrefs('ch-byok-status', { provider: 'azure' });
 
-    const result = handleCommand('ch-byok-status', '/status', SESSION_INFO, PREFS,
+    const result = await handleCommand('ch-byok-status', '/status', SESSION_INFO, PREFS,
       undefined, MODELS);
     expect(result.response).not.toContain('Reasoning effort');
     expect(result.response).not.toContain('🧠');
@@ -451,9 +451,9 @@ describe('BYOK reasoning effort suppression', () => {
 
   it('/status shows reasoning effort for Copilot model (no provider)', async () => {
     const { setChannelPrefs } = await import('../state/store.js');
-    setChannelPrefs('ch-copilot-status', { provider: undefined });
+    await setChannelPrefs('ch-copilot-status', { provider: undefined });
 
-    const result = handleCommand('ch-copilot-status', '/status', SESSION_INFO, PREFS,
+    const result = await handleCommand('ch-copilot-status', '/status', SESSION_INFO, PREFS,
       undefined, MODELS);
     expect(result.response).toContain('Reasoning effort');
     expect(result.response).toContain('🧠');
@@ -461,9 +461,9 @@ describe('BYOK reasoning effort suppression', () => {
 
   it('/reasoning rejects unsupported level for BYOK model', async () => {
     const { setChannelPrefs } = await import('../state/store.js');
-    setChannelPrefs('ch-byok-reason', { provider: 'azure' });
+    await setChannelPrefs('ch-byok-reason', { provider: 'azure' });
 
-    const result = handleCommand('ch-byok-reason', '/reasoning high', SESSION_INFO, PREFS,
+    const result = await handleCommand('ch-byok-reason', '/reasoning high', SESSION_INFO, PREFS,
       undefined, MODELS);
     // BYOK model has no supportedReasoningEfforts, so currentModelInfo is the BYOK entry
     // The command should still set the level (it only blocks if model explicitly doesn't support it)
@@ -472,32 +472,32 @@ describe('BYOK reasoning effort suppression', () => {
 });
 
 describe('/always command', () => {
-  it('/always approve returns remember action', () => {
-    const result = handleCommand('ch-always-1', '/always approve');
+  it('/always approve returns remember action', async () => {
+    const result = await handleCommand('ch-always-1', '/always approve');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('remember');
   });
 
-  it('/always deny returns remember_deny action', () => {
-    const result = handleCommand('ch-always-2', '/always deny');
+  it('/always deny returns remember_deny action', async () => {
+    const result = await handleCommand('ch-always-2', '/always deny');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('remember_deny');
   });
 
-  it('/always with no args shows usage', () => {
-    const result = handleCommand('ch-always-3', '/always');
+  it('/always with no args shows usage', async () => {
+    const result = await handleCommand('ch-always-3', '/always');
     expect(result.handled).toBe(true);
     expect(result.response).toContain('Usage');
   });
 
-  it('/always with invalid arg shows usage', () => {
-    const result = handleCommand('ch-always-4', '/always banana');
+  it('/always with invalid arg shows usage', async () => {
+    const result = await handleCommand('ch-always-4', '/always banana');
     expect(result.handled).toBe(true);
     expect(result.response).toContain('Usage');
   });
 
-  it('/remember still works as alias for approve+persist', () => {
-    const result = handleCommand('ch-always-5', '/remember');
+  it('/remember still works as alias for approve+persist', async () => {
+    const result = await handleCommand('ch-always-5', '/remember');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('remember');
   });
@@ -506,68 +506,68 @@ describe('/always command', () => {
 // --- /skills command ---
 
 describe('/skills command', () => {
-  it('/skills with no args returns skills action', () => {
-    const result = handleCommand('ch-skills-1', '/skills');
+  it('/skills with no args returns skills action', async () => {
+    const result = await handleCommand('ch-skills-1', '/skills');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('skills');
   });
 
-  it('/tools aliases to skills', () => {
-    const result = handleCommand('ch-skills-2', '/tools');
+  it('/tools aliases to skills', async () => {
+    const result = await handleCommand('ch-skills-2', '/tools');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('skills');
   });
 
-  it('/skills disable <name> returns skill_toggle with single target', () => {
-    const result = handleCommand('ch-skills-3', '/skills disable humanizer');
+  it('/skills disable <name> returns skill_toggle with single target', async () => {
+    const result = await handleCommand('ch-skills-3', '/skills disable humanizer');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('skill_toggle');
     expect(result.payload).toEqual({ action: 'disable', targets: ['humanizer'] });
   });
 
-  it('/skills enable <name> returns skill_toggle', () => {
-    const result = handleCommand('ch-skills-4', '/skills enable humanizer');
+  it('/skills enable <name> returns skill_toggle', async () => {
+    const result = await handleCommand('ch-skills-4', '/skills enable humanizer');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('skill_toggle');
     expect(result.payload).toEqual({ action: 'enable', targets: ['humanizer'] });
   });
 
-  it('/skills disable all passes "all" as target', () => {
-    const result = handleCommand('ch-skills-5', '/skills disable all');
+  it('/skills disable all passes "all" as target', async () => {
+    const result = await handleCommand('ch-skills-5', '/skills disable all');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('skill_toggle');
     expect(result.payload).toEqual({ action: 'disable', targets: ['all'] });
   });
 
-  it('/skills enable all passes "all" as target', () => {
-    const result = handleCommand('ch-skills-6', '/skills enable all');
+  it('/skills enable all passes "all" as target', async () => {
+    const result = await handleCommand('ch-skills-6', '/skills enable all');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('skill_toggle');
     expect(result.payload).toEqual({ action: 'enable', targets: ['all'] });
   });
 
-  it('/skills disable with multiple names returns all targets', () => {
-    const result = handleCommand('ch-skills-7', '/skills disable humanizer pdf xlsx');
+  it('/skills disable with multiple names returns all targets', async () => {
+    const result = await handleCommand('ch-skills-7', '/skills disable humanizer pdf xlsx');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('skill_toggle');
     expect(result.payload).toEqual({ action: 'disable', targets: ['humanizer', 'pdf', 'xlsx'] });
   });
 
-  it('/skills enable with multiple names returns all targets', () => {
-    const result = handleCommand('ch-skills-8', '/skills enable humanizer pdf');
+  it('/skills enable with multiple names returns all targets', async () => {
+    const result = await handleCommand('ch-skills-8', '/skills enable humanizer pdf');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('skill_toggle');
     expect(result.payload).toEqual({ action: 'enable', targets: ['humanizer', 'pdf'] });
   });
 
-  it('/skills with unrecognized subcommand falls through to skills action', () => {
-    const result = handleCommand('ch-skills-9', '/skills info');
+  it('/skills with unrecognized subcommand falls through to skills action', async () => {
+    const result = await handleCommand('ch-skills-9', '/skills info');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('skills');
   });
 
-  it('/tools disable also works as alias', () => {
-    const result = handleCommand('ch-skills-10', '/tools disable humanizer');
+  it('/tools disable also works as alias', async () => {
+    const result = await handleCommand('ch-skills-10', '/tools disable humanizer');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('skill_toggle');
     expect(result.payload).toEqual({ action: 'disable', targets: ['humanizer'] });

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -26,8 +26,8 @@ function redactedModelLabel(index: number): string {
 }
 
 /** Check if streamer mode is currently enabled. */
-function isStreamerMode(): boolean {
-  return getGlobalSetting('streamer_mode') === '1';
+async function isStreamerMode(): Promise<boolean> {
+  return await getGlobalSetting('streamer_mode') === '1';
 }
 
 export interface ModelInfo {
@@ -168,8 +168,8 @@ function fuzzyMatch(input: string, models: ModelInfo[], scope?: string): { model
 }
 
 /** Build the formatted model listing, optionally grouped by provider. */
-function formatModelListing(models: ModelInfo[], providerNames: string[], currentModel: string | null, currentProvider: string | null, filterProvider?: string): string {
-  const streamer = isStreamerMode();
+async function formatModelListing(models: ModelInfo[], providerNames: string[], currentModel: string | null, currentProvider: string | null, filterProvider?: string): Promise<string> {
+  const streamer = await isStreamerMode();
   let hiddenIndex = 0;
 
   // Determine if the current model matches a given model entry
@@ -318,7 +318,7 @@ export interface McpServerInfo {
   pending?: boolean;
 }
 
-export function handleCommand(channelId: string, text: string, sessionInfo?: { sessionId: string; model: string; agent: string | null }, effectivePrefs?: { verbose: boolean; permissionMode: string; reasoningEffort?: string | null }, channelMeta?: { workingDirectory?: string; bot?: string }, models?: ModelInfo[], mcpInfo?: McpServerInfo[], contextUsage?: { currentTokens: number; tokenLimit: number; contextWindowTokens?: number } | null, providers?: Record<string, BridgeProviderConfig>): CommandResult {
+export async function handleCommand(channelId: string, text: string, sessionInfo?: { sessionId: string; model: string; agent: string | null }, effectivePrefs?: { verbose: boolean; permissionMode: string; reasoningEffort?: string | null }, channelMeta?: { workingDirectory?: string; bot?: string }, models?: ModelInfo[], mcpInfo?: McpServerInfo[], contextUsage?: { currentTokens: number; tokenLimit: number; contextWindowTokens?: number } | null, providers?: Record<string, BridgeProviderConfig>): Promise<CommandResult> {
   const parsed = parseCommand(text);
   if (!parsed) return { handled: false };
 
@@ -326,7 +326,7 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
   // When a BYOK provider is active, prefer the provider-prefixed entry to avoid
   // inheriting metadata (e.g., supportedReasoningEfforts) from a same-named Copilot model
   const needsModelInfo = ['reasoning', 'status', 'model', 'models'].includes(parsed.command);
-  const currentProvider = needsModelInfo ? (getChannelPrefs(channelId)?.provider ?? null) : null;
+  const currentProvider = needsModelInfo ? ((await getChannelPrefs(channelId))?.provider ?? null) : null;
   const currentModelInfo = needsModelInfo && models && sessionInfo
     ? (currentProvider
         ? models.find(m => m.id === `${currentProvider}:${sessionInfo.model}`) ?? null
@@ -365,14 +365,14 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
     case 'model':
     case 'models': {
       const providerNames = providers ? Object.keys(providers) : [];
-      const currentProvider = getChannelPrefs(channelId)?.provider ?? null;
+      const currentProvider = (await getChannelPrefs(channelId))?.provider ?? null;
 
       if (!parsed.args) {
         // No args: show model table grouped by provider
         if (!models || models.length === 0) {
           return { handled: true, response: '⚠️ Model list not available.' };
         }
-        return { handled: true, response: formatModelListing(models, providerNames, sessionInfo?.model ?? null, currentProvider) };
+        return { handled: true, response: await formatModelListing(models, providerNames, sessionInfo?.model ?? null, currentProvider) };
       }
 
       // Check if arg is a provider name → show just that provider's models
@@ -385,7 +385,7 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
         if (provModels.length === 0) {
           return { handled: true, response: `⚠️ No models found for provider "${provName}".` };
         }
-        return { handled: true, response: formatModelListing(provModels, providerNames, sessionInfo?.model ?? null, currentProvider, provName) };
+        return { handled: true, response: await formatModelListing(provModels, providerNames, sessionInfo?.model ?? null, currentProvider, provName) };
       }
 
       if (!models || models.length === 0) {
@@ -404,7 +404,7 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
       const resolvedProvider = providerNames.find(p => result.model.id.toLowerCase().startsWith(`${p.toLowerCase()}:`)) ?? null;
       const bareModelId = resolvedProvider ? result.model.id.slice(resolvedProvider.length + 1) : result.model.id;
 
-      const streamerSwitch = isStreamerMode();
+      const streamerSwitch = await isStreamerMode();
       const switchName = (streamerSwitch && isHiddenModel(result.model))
         ? 'a hidden model'
         : `**${result.model.name}** (\`${result.model.id}\`)`;
@@ -525,10 +525,10 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
     }
 
     case 'verbose': {
-      const prefs = getChannelPrefs(channelId);
+      const prefs = await getChannelPrefs(channelId);
       const current = effectivePrefs?.verbose ?? prefs?.verbose ?? false;
       const newVerbose = parsed.args ? parseBool(parsed.args, !current) : !current;
-      setChannelPrefs(channelId, { verbose: newVerbose });
+      await setChannelPrefs(channelId, { verbose: newVerbose });
       return {
         handled: true,
         action: 'toggle_verbose',
@@ -546,12 +546,12 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
         return { handled: true, response: `⚠️ Invalid reasoning effort. Valid values: \`low\`, \`medium\`, \`high\`, \`xhigh\`` };
       }
       if (currentModelInfo && currentModelInfo.supportedReasoningEfforts && !currentModelInfo.supportedReasoningEfforts.includes(level)) {
-        const reasoningModelName = (isStreamerMode() && isHiddenModel(currentModelInfo))
+        const reasoningModelName = (await isStreamerMode() && isHiddenModel(currentModelInfo))
           ? 'the current model'
           : `**${sessionInfo?.model ?? 'unknown'}**`;
         return { handled: true, response: `⚠️ Model ${reasoningModelName} does not support reasoning effort.\nSupported models include Opus and other reasoning-capable models.` };
       }
-      setChannelPrefs(channelId, { reasoningEffort: level });
+      await setChannelPrefs(channelId, { reasoningEffort: level });
       return {
         handled: true,
         action: 'set_reasoning',
@@ -563,8 +563,8 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
       if (!sessionInfo) {
         return { handled: true, response: '📊 No active session for this channel.' };
       }
-      const prefs = getChannelPrefs(channelId);
-      const streamerStatus = isStreamerMode();
+      const prefs = await getChannelPrefs(channelId);
+      const streamerStatus = await isStreamerMode();
       const modelDisplay = (streamerStatus && currentModelInfo && isHiddenModel(currentModelInfo))
         ? 'Hidden Model'
         : sessionInfo.model;
@@ -615,10 +615,10 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
       return { handled: true, action: 'toggle_autopilot' };
 
     case 'yolo': {
-      const prefs = getChannelPrefs(channelId);
+      const prefs = await getChannelPrefs(channelId);
       const current = effectivePrefs?.permissionMode ?? prefs?.permissionMode ?? 'interactive';
       const newMode = current === 'autopilot' ? 'interactive' : 'autopilot';
-      setChannelPrefs(channelId, { permissionMode: newMode });
+      await setChannelPrefs(channelId, { permissionMode: newMode });
       return {
         handled: true,
         response: newMode === 'autopilot'
@@ -663,9 +663,9 @@ export function handleCommand(channelId: string, text: string, sessionInfo?: { s
 
     case 'streamer-mode':
     case 'on-air': {
-      const current = isStreamerMode();
+      const current = await isStreamerMode();
       const newValue = parsed.args ? parseBool(parsed.args, !current) : !current;
-      setGlobalSetting('streamer_mode', newValue ? '1' : '0');
+      await setGlobalSetting('streamer_mode', newValue ? '1' : '0');
       return {
         handled: true,
         response: newValue

--- a/src/core/inter-agent.ts
+++ b/src/core/inter-agent.ts
@@ -116,7 +116,7 @@ export function extendContext(context: InterAgentContext, nextBot: string): Inte
  * Get all working directories for channels served by a given bot.
  * Queries both static config and dynamic channels.
  */
-export function getBotWorkspaceMap(botName: string): BotWorkspaceEntry[] {
+export async function getBotWorkspaceMap(botName: string): Promise<BotWorkspaceEntry[]> {
   const config = getConfig();
   const entries: BotWorkspaceEntry[] = [];
   const seen = new Set<string>(); // dedupe by channelId
@@ -135,7 +135,7 @@ export function getBotWorkspaceMap(botName: string): BotWorkspaceEntry[] {
   }
 
   // Dynamic channels from SQLite
-  for (const dyn of getDynamicChannels()) {
+  for (const dyn of await getDynamicChannels()) {
     const channelBot = dyn.bot ?? getDefaultBotForPlatform(dyn.platform);
     if (channelBot === botName && !seen.has(dyn.channelId)) {
       seen.add(dyn.channelId);

--- a/src/core/onboarding.ts
+++ b/src/core/onboarding.ts
@@ -189,7 +189,7 @@ export async function onboardProject(
 
   // initWorkspace handles AGENTS.md and MEMORY.md creation (skips if exists)
   try {
-    initWorkspace(opts.botName ?? 'copilot', workspacePath, false);
+    await initWorkspace(opts.botName ?? 'copilot', workspacePath, false);
     steps.push(`Workspace initialized at ${workspacePath}`);
   } catch (err: any) {
     steps.push(`⚠️ Workspace init warning: ${err?.message}`);
@@ -200,7 +200,7 @@ export async function onboardProject(
   const triggerMode = opts.triggerMode ?? config.defaults.triggerMode;
   const threadedReplies = opts.threadedReplies ?? config.defaults.threadedReplies;
 
-  addDynamicChannel({
+  await addDynamicChannel({
     channelId,
     platform: opts.platform,
     name: channelName,

--- a/src/core/plan-mode.test.ts
+++ b/src/core/plan-mode.test.ts
@@ -47,22 +47,22 @@ describe('extractPlanSummary', () => {
 // --- /implement command ---
 
 describe('/implement command', () => {
-  it('returns implement action with no args', () => {
-    const result = handleCommand('ch1', '/implement');
+  it('returns implement action with no args', async () => {
+    const result = await handleCommand('ch1', '/implement');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('implement');
     expect(result.payload).toBeUndefined();
   });
 
-  it('returns implement action with yolo arg', () => {
-    const result = handleCommand('ch1', '/implement yolo');
+  it('returns implement action with yolo arg', async () => {
+    const result = await handleCommand('ch1', '/implement yolo');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('implement');
     expect(result.payload).toBe('yolo');
   });
 
-  it('returns implement action with interactive arg', () => {
-    const result = handleCommand('ch1', '/implement interactive');
+  it('returns implement action with interactive arg', async () => {
+    const result = await handleCommand('ch1', '/implement interactive');
     expect(result.handled).toBe(true);
     expect(result.action).toBe('implement');
     expect(result.payload).toBe('interactive');

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -43,9 +43,9 @@ export function describeCron(cronExpr: string): string {
 let deps: SchedulerDeps | null = null;
 
 /** Initialize the scheduler — load persisted jobs and start them. */
-export function initScheduler(schedulerDeps: SchedulerDeps): void {
+export async function initScheduler(schedulerDeps: SchedulerDeps): Promise<void> {
   deps = schedulerDeps;
-  const tasks = getEnabledScheduledTasks();
+  const tasks = await getEnabledScheduledTasks();
   let started = 0;
   let missed = 0;
   const missedByChannel = new Map<string, string[]>();
@@ -58,7 +58,7 @@ export function initScheduler(schedulerDeps: SchedulerDeps): void {
       list.push(task.description ?? task.prompt.slice(0, 60));
       missedByChannel.set(task.channelId, list);
       // Delete the one-off (it won't run again)
-      deleteScheduledTask(task.id);
+      await deleteScheduledTask(task.id);
       continue;
     }
 
@@ -75,7 +75,7 @@ export function initScheduler(schedulerDeps: SchedulerDeps): void {
     const summary = descriptions.length === 1
       ? descriptions[0]
       : `${descriptions.length} tasks: ${descriptions.join(', ')}`;
-    insertTaskHistory({
+    await insertTaskHistory({
       taskId: 'system', channelId,
       prompt: summary, description: `Missed while offline`,
       timezone: 'UTC',
@@ -91,7 +91,7 @@ export function initScheduler(schedulerDeps: SchedulerDeps): void {
 }
 
 /** Create and persist a new scheduled task. */
-export function addJob(opts: {
+export async function addJob(opts: {
   channelId: string;
   botName: string;
   prompt: string;
@@ -100,7 +100,7 @@ export function addJob(opts: {
   timezone?: string;
   createdBy?: string;
   description?: string;
-}): ScheduledTask {
+}): Promise<ScheduledTask> {
   if (!opts.cronExpr && !opts.runAt) {
     throw new Error('Either cronExpr or runAt must be provided');
   }
@@ -141,15 +141,15 @@ export function addJob(opts: {
     createdAt: new Date().toISOString(),
   };
 
-  insertScheduledTask(task);
+  await insertScheduledTask(task);
   startJob(task);
   log.info(`Job ${id} created: ${opts.description ?? opts.cronExpr ?? opts.runAt}`);
   return task;
 }
 
 /** Remove a job (stops and deletes from DB). Optionally scoped to a channel. */
-export function removeJob(id: string, channelId?: string): boolean {
-  const task = getScheduledTask(id);
+export async function removeJob(id: string, channelId?: string): Promise<boolean> {
+  const task = await getScheduledTask(id);
   if (!task) return false;
   if (channelId && task.channelId !== channelId) return false;
   const existing = activeJobs.get(id);
@@ -157,14 +157,14 @@ export function removeJob(id: string, channelId?: string): boolean {
     existing.stop();
     activeJobs.delete(id);
   }
-  deleteScheduledTask(id);
+  await deleteScheduledTask(id);
   log.info(`Job ${id} removed`);
   return true;
 }
 
 /** Pause a job (stops timer, keeps in DB). Optionally scoped to a channel. */
-export function pauseJob(id: string, channelId?: string): boolean {
-  const task = getScheduledTask(id);
+export async function pauseJob(id: string, channelId?: string): Promise<boolean> {
+  const task = await getScheduledTask(id);
   if (!task) return false;
   if (channelId && task.channelId !== channelId) return false;
   const job = activeJobs.get(id);
@@ -172,37 +172,37 @@ export function pauseJob(id: string, channelId?: string): boolean {
     job.stop();
     activeJobs.delete(id);
   }
-  updateScheduledTaskEnabled(id, false);
+  await updateScheduledTaskEnabled(id, false);
   log.info(`Job ${id} paused`);
   return true;
 }
 
 /** Resume a paused job. Optionally scoped to a channel. */
-export function resumeJob(id: string, channelId?: string): boolean {
-  const task = getScheduledTask(id);
+export async function resumeJob(id: string, channelId?: string): Promise<boolean> {
+  const task = await getScheduledTask(id);
   if (!task) return false;
   if (channelId && task.channelId !== channelId) return false;
-  updateScheduledTaskEnabled(id, true);
+  await updateScheduledTaskEnabled(id, true);
   try {
     startJob({ ...task, enabled: true });
     log.info(`Job ${id} resumed`);
     return true;
   } catch (err: any) {
-    updateScheduledTaskEnabled(id, false);
+    await updateScheduledTaskEnabled(id, false);
     log.error(`Failed to resume job ${id}: ${err?.message}`);
     return false;
   }
 }
 
 /** List jobs for a channel (or all if no channelId). */
-export function listJobs(channelId?: string): ScheduledTask[] {
-  if (channelId) return getScheduledTasksForChannel(channelId);
-  return getEnabledScheduledTasks();
+export async function listJobs(channelId?: string): Promise<ScheduledTask[]> {
+  if (channelId) return await getScheduledTasksForChannel(channelId);
+  return await getEnabledScheduledTasks();
 }
 
 /** Get a job by ID. */
-export function getJob(id: string): ScheduledTask | null {
-  return getScheduledTask(id);
+export async function getJob(id: string): Promise<ScheduledTask | null> {
+  return await getScheduledTask(id);
 }
 
 /** Stop all active jobs (for shutdown). */
@@ -241,7 +241,7 @@ async function executeJob(taskId: string, isOneOff: boolean): Promise<void> {
     return;
   }
 
-  const task = getScheduledTask(taskId);
+  const task = await getScheduledTask(taskId);
   if (!task || !task.enabled) return;
 
   const now = new Date().toISOString();
@@ -250,7 +250,7 @@ async function executeJob(taskId: string, isOneOff: boolean): Promise<void> {
   try {
     await deps.sendMessage(task.channelId, task.prompt);
 
-    insertTaskHistory({
+    await insertTaskHistory({
       taskId: task.id, channelId: task.channelId,
       prompt: task.prompt, description: task.description,
       timezone: task.timezone,
@@ -265,11 +265,11 @@ async function executeJob(taskId: string, isOneOff: boolean): Promise<void> {
         nextRun = job.nextDate().toISO() ?? undefined;
       }
     }
-    updateScheduledTaskLastRun(taskId, now, nextRun);
+    await updateScheduledTaskLastRun(taskId, now, nextRun);
   } catch (err: any) {
     log.error(`Job ${taskId} execution failed: ${err?.message}`);
     try {
-      insertTaskHistory({
+      await insertTaskHistory({
         taskId: task.id, channelId: task.channelId,
         prompt: task.prompt, description: task.description,
         timezone: task.timezone,
@@ -285,7 +285,7 @@ async function executeJob(taskId: string, isOneOff: boolean): Promise<void> {
     const job = activeJobs.get(taskId);
     if (job) job.stop();
     activeJobs.delete(taskId);
-    deleteScheduledTask(taskId);
+    await deleteScheduledTask(taskId);
     log.info(`One-off job ${taskId} completed and removed`);
   }
 }

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -432,7 +432,7 @@ export class SessionManager {
   private yoloPreviousState = new Map<string, string>();
   // Handler for send_file tool (set by index.ts, calls adapter.sendFile)
   private sendFileHandler: ((channelId: string, filePath: string, message?: string) => Promise<string>) | null = null;
-  private getAdapterForChannel: ((channelId: string) => ChannelAdapter | null) | null = null;
+  private getAdapterForChannel: ((channelId: string) => ChannelAdapter | null | Promise<ChannelAdapter | null>) | null = null;
 
   constructor(bridge: CopilotBridge) {
     this.bridge = bridge;
@@ -523,7 +523,7 @@ export class SessionManager {
   }
 
   /** Register adapter resolver for onboarding tools. */
-  onGetAdapter(resolver: (channelId: string) => ChannelAdapter | null): void {
+  onGetAdapter(resolver: (channelId: string) => ChannelAdapter | null | Promise<ChannelAdapter | null>): void {
     this.getAdapterForChannel = resolver;
   }
 
@@ -537,8 +537,8 @@ export class SessionManager {
   }
 
   /** Get annotated MCP server info for a channel, showing which layer each server came from. */
-  getMcpServerInfo(channelId: string): McpServerInfo[] {
-    const workingDirectory = this.resolveWorkingDirectory(channelId);
+  async getMcpServerInfo(channelId: string): Promise<McpServerInfo[]> {
+    const workingDirectory = await this.resolveWorkingDirectory(channelId);
     const { servers: workspaceServers } = loadWorkspaceMcpServers(workingDirectory);
     const globalNames = new Set(Object.keys(this.mcpServers));
     const sessionServers = this.sessionMcpServers.get(channelId);
@@ -565,11 +565,11 @@ export class SessionManager {
   }
 
   /** Get skill info for a channel — discovers skills and reads their descriptions from SKILL.md frontmatter. */
-  getSkillInfo(channelId: string): { name: string; description: string; source: string; pending?: boolean; disabled?: boolean }[] {
-    const workingDirectory = this.resolveWorkingDirectory(channelId);
+  async getSkillInfo(channelId: string): Promise<{ name: string; description: string; source: string; pending?: boolean; disabled?: boolean }[]> {
+    const workingDirectory = await this.resolveWorkingDirectory(channelId);
     const dirs = discoverSkillDirectories(workingDirectory);
     const sessionDirs = this.sessionSkillDirs.get(channelId);
-    const prefs = getChannelPrefs(channelId);
+    const prefs = await getChannelPrefs(channelId);
     const disabledSet = new Set(prefs?.disabledSkills ?? []);
     const skills: { name: string; description: string; source: string; pending?: boolean; disabled?: boolean }[] = [];
     const home = process.env.HOME;
@@ -604,8 +604,8 @@ export class SessionManager {
   }
 
   /** Get info about configured hooks for a channel's workspace. */
-  getHooksInfo(channelId: string): HookInfo[] {
-    const workingDirectory = this.resolveWorkingDirectory(channelId);
+  async getHooksInfo(channelId: string): Promise<HookInfo[]> {
+    const workingDirectory = await this.resolveWorkingDirectory(channelId);
     const allowWorkspaceHooks = getConfig().defaults.allowWorkspaceHooks ?? false;
     return getHooksInfo(workingDirectory, { allowWorkspaceHooks });
   }
@@ -632,14 +632,14 @@ export class SessionManager {
     }
 
     // Check SQLite for persisted session
-    const storedSessionId = getChannelSession(channelId);
+    const storedSessionId = await getChannelSession(channelId);
     if (storedSessionId) {
       try {
         await this.attachSession(channelId, storedSessionId);
         return { sessionId: storedSessionId, isNew: false };
       } catch (err) {
       log.warn(`Failed to resume session ${storedSessionId} for channel ${channelId}, creating new:`, err);
-        clearChannelSession(channelId);
+        await clearChannelSession(channelId);
       }
     }
 
@@ -666,17 +666,17 @@ export class SessionManager {
       this.sessionMcpServers.delete(channelId);
       this.sessionSkillDirs.delete(channelId);
       this.pendingPlanExit.delete(channelId);
-      this.revertYoloIfNeeded(channelId);
+      await this.revertYoloIfNeeded(channelId);
       const debounceTimer = this.planChangedDebounce.get(channelId);
       if (debounceTimer) { clearTimeout(debounceTimer); this.planChangedDebounce.delete(channelId); }
     }
-    clearChannelSession(channelId);
+    await clearChannelSession(channelId);
     return this.createNewSession(channelId);
   }
 
   /** Reload the current session — detach and re-attach to pick up AGENTS.md / config changes. */
   async reloadSession(channelId: string): Promise<string> {
-    const existingId = this.channelSessions.get(channelId) ?? getChannelSession(channelId) ?? undefined;
+    const existingId = this.channelSessions.get(channelId) ?? await getChannelSession(channelId) ?? undefined;
     if (!existingId) {
       // No session to reload — just create one
       return this.createNewSession(channelId);
@@ -698,7 +698,7 @@ export class SessionManager {
     this.sessionMcpServers.delete(channelId);
     this.sessionSkillDirs.delete(channelId);
     this.pendingPlanExit.delete(channelId);
-    this.revertYoloIfNeeded(channelId);
+    await this.revertYoloIfNeeded(channelId);
     { const dt = this.planChangedDebounce.get(channelId); if (dt) { clearTimeout(dt); this.planChangedDebounce.delete(channelId); } }
     try {
       await this.attachSession(channelId, existingId);
@@ -716,7 +716,7 @@ export class SessionManager {
       this.sessionSkillDirs.delete(channelId);
       this.pendingPlanExit.delete(channelId);
       // yoloPreviousState already reverted above
-      clearChannelSession(channelId);
+      await clearChannelSession(channelId);
       return this.createNewSession(channelId);
     }
   }
@@ -742,7 +742,7 @@ export class SessionManager {
       this.sessionMcpServers.delete(channelId);
       this.sessionSkillDirs.delete(channelId);
       this.pendingPlanExit.delete(channelId);
-      this.revertYoloIfNeeded(channelId);
+      await this.revertYoloIfNeeded(channelId);
       { const dt = this.planChangedDebounce.get(channelId); if (dt) { clearTimeout(dt); this.planChangedDebounce.delete(channelId); } }
     }
 
@@ -760,15 +760,15 @@ export class SessionManager {
       this.sessionMcpServers.delete(otherChannel);
       this.sessionSkillDirs.delete(otherChannel);
       this.pendingPlanExit.delete(otherChannel);
-      this.revertYoloIfNeeded(otherChannel);
+      await this.revertYoloIfNeeded(otherChannel);
       { const dt = this.planChangedDebounce.get(otherChannel); if (dt) { clearTimeout(dt); this.planChangedDebounce.delete(otherChannel); } }
-      clearChannelSession(otherChannel);
+      await clearChannelSession(otherChannel);
     }
 
     // Attach to the target session — fail hard if it doesn't exist
     // (user explicitly asked for this session, don't silently replace it)
     await this.attachSession(channelId, targetSessionId);
-    setChannelSession(channelId, targetSessionId);
+    await setChannelSession(channelId, targetSessionId);
     log.info(`Resumed session ${targetSessionId} for channel ${channelId}`);
     return targetSessionId;
   }
@@ -797,8 +797,8 @@ export class SessionManager {
       // a new session so the fallback model is used for both creation and send
       if (isModelError(err)) {
         log.info(`Model error detected — switching to fallback model for channel ${channelId}...`);
-        const prefs = this.getEffectivePrefs(channelId);
-        const configChannel = getChannelConfig(channelId);
+        const prefs = await this.getEffectivePrefs(channelId);
+        const configChannel = await getChannelConfig(channelId);
         const configFallbacks = configChannel.fallbackModels ?? getConfig().defaults.fallbackModels;
 
         let availableModels: string[] = [];
@@ -815,7 +815,7 @@ export class SessionManager {
         for (const fallbackModel of chain) {
           try {
             log.info(`Trying send with fallback model "${fallbackModel}"...`);
-            setChannelPrefs(channelId, { model: fallbackModel });
+            await setChannelPrefs(channelId, { model: fallbackModel });
             const newSessionId = await this.newSession(channelId);
             const newSession = this.bridge.getSession(newSessionId);
             if (!newSession) continue;
@@ -836,7 +836,7 @@ export class SessionManager {
         }
 
         // If no fallback worked, restore original model pref and throw
-        setChannelPrefs(channelId, { model: prefs.model });
+        await setChannelPrefs(channelId, { model: prefs.model });
         throw lastError;
       }
 
@@ -926,7 +926,7 @@ export class SessionManager {
           // Clear stale session so ensureSession() creates fresh on next call
           this.channelSessions.delete(channelId);
           this.sessionChannels.delete(sessionId);
-          clearChannelSession(channelId);
+          await clearChannelSession(channelId);
           throw err;
         }
         // Last resort: new session
@@ -946,7 +946,7 @@ export class SessionManager {
    * session is stale (backend no longer recognizes it).
    */
   async reloadMcp(channelId: string): Promise<void> {
-    const sessionId = this.channelSessions.get(channelId) ?? getChannelSession(channelId);
+    const sessionId = this.channelSessions.get(channelId) ?? await getChannelSession(channelId);
     const session = sessionId ? this.bridge.getSession(sessionId) : undefined;
     if (!session) {
       log.info(`No active session for ${channelId.slice(0, 8)}... — falling back to full reload`);
@@ -974,7 +974,7 @@ export class SessionManager {
    * session is stale.
    */
   async reloadSkills(channelId: string): Promise<void> {
-    const sessionId = this.channelSessions.get(channelId) ?? getChannelSession(channelId);
+    const sessionId = this.channelSessions.get(channelId) ?? await getChannelSession(channelId);
     const session = sessionId ? this.bridge.getSession(sessionId) : undefined;
     if (!session) {
       log.info(`No active session for ${channelId.slice(0, 8)}... — falling back to full reload`);
@@ -999,7 +999,7 @@ export class SessionManager {
    * Silently no-ops if no active session (pref is already persisted).
    */
   async toggleSkillRpc(channelId: string, skillName: string, action: 'enable' | 'disable'): Promise<void> {
-    const sessionId = this.channelSessions.get(channelId) ?? getChannelSession(channelId);
+    const sessionId = this.channelSessions.get(channelId) ?? await getChannelSession(channelId);
     const session = sessionId ? this.bridge.getSession(sessionId) : undefined;
     if (!session) return; // Pref already persisted; will apply on next session create
     if (action === 'enable') {
@@ -1012,7 +1012,7 @@ export class SessionManager {
 
   /** Switch the model for a channel's session. */
   async switchModel(channelId: string, model: string, provider?: string | null): Promise<void> {
-    const currentPrefs = this.getEffectivePrefs(channelId);
+    const currentPrefs = await this.getEffectivePrefs(channelId);
     const currentProvider = currentPrefs.provider ?? null;
     const newProvider = provider ?? null;
     const providerChanged = currentProvider !== newProvider;
@@ -1023,41 +1023,41 @@ export class SessionManager {
       // Set prefs before newSession so createNewSession picks up the new provider,
       // but restore on failure so the channel isn't left in a broken state.
       const prevModel = currentPrefs.model;
-      setChannelPrefs(channelId, { model, provider: newProvider });
+      await setChannelPrefs(channelId, { model, provider: newProvider });
       try {
         await this.newSession(channelId);
       } catch (err) {
         log.warn(`Provider switch failed, reverting prefs:`, err);
-        setChannelPrefs(channelId, { model: prevModel, provider: currentProvider });
+        await setChannelPrefs(channelId, { model: prevModel, provider: currentProvider });
         throw err;
       }
     } else if (newProvider && this.wireApiChanged(newProvider, currentPrefs.model ?? '', model)) {
       // Same provider but wireApi differs between models — need fresh session
       log.info(`wireApi change for provider ${newProvider}, model ${currentPrefs.model} → ${model} — creating new session`);
       const prevModel = currentPrefs.model;
-      setChannelPrefs(channelId, { model, provider: newProvider });
+      await setChannelPrefs(channelId, { model, provider: newProvider });
       try {
         await this.newSession(channelId);
       } catch (err) {
         log.warn(`wireApi switch failed, reverting prefs:`, err);
-        setChannelPrefs(channelId, { model: prevModel, provider: currentProvider });
+        await setChannelPrefs(channelId, { model: prevModel, provider: currentProvider });
         throw err;
       }
     } else {
       // Same provider — use RPC model switch (with session retry)
       await this.withSessionRetry(channelId, (sid) => this.bridge.switchSessionModel(sid, model));
-      setChannelPrefs(channelId, { model, provider: newProvider });
+      await setChannelPrefs(channelId, { model, provider: newProvider });
     }
 
     // Clear stale context window tokens so /context falls back to tokenLimit during transition
     this.contextWindowTokens.delete(channelId);
 
     // Update cached context window tokens for the new model (best-effort)
-    this.bridge.listModels(getConfig().providers).then(models => {
+    this.bridge.listModels(getConfig().providers).then(async (models) => {
       // Guard against rapid switches: only cache if the channel is still on this model
-      const prefs = this.getEffectivePrefs(channelId);
+      const prefs = await this.getEffectivePrefs(channelId);
       if (prefs.model === model) {
-        this.cacheContextWindowTokens(channelId, model, models);
+        await this.cacheContextWindowTokens(channelId, model, models);
       }
     }).catch(() => { /* best-effort */ });
   }
@@ -1084,7 +1084,7 @@ export class SessionManager {
         await this.bridge.deselectAgent(sid);
       }
     });
-    setChannelPrefs(channelId, { agent });
+    await setChannelPrefs(channelId, { agent });
   }
 
   /**
@@ -1092,18 +1092,18 @@ export class SessionManager {
    * Uses the current model so only the reasoning effort changes — no full session reload needed.
    */
   async setReasoningEffort(channelId: string, effort: string): Promise<void> {
-    const prefs = this.getEffectivePrefs(channelId);
+    const prefs = await this.getEffectivePrefs(channelId);
     const model = prefs.model;
     await this.withSessionRetry(channelId, (sid) =>
       this.bridge.switchSessionModel(sid, model, { reasoningEffort: effort })
     );
-    setChannelPrefs(channelId, { reasoningEffort: effort });
+    await setChannelPrefs(channelId, { reasoningEffort: effort });
   }
 
   /** Get effective preferences for a channel (config merged with runtime overrides). */
-  getEffectivePrefs(channelId: string): ChannelPrefs & { model: string; verbose: boolean; threadedReplies: boolean; permissionMode: string; triggerMode: 'mention' | 'all' } {
-    const configChannel = getChannelConfig(channelId);
-    const storedPrefs = getChannelPrefs(channelId);
+  async getEffectivePrefs(channelId: string): Promise<ChannelPrefs & { model: string; verbose: boolean; threadedReplies: boolean; permissionMode: string; triggerMode: 'mention' | 'all' }> {
+    const configChannel = await getChannelConfig(channelId);
+    const storedPrefs = await getChannelPrefs(channelId);
     return {
       model: storedPrefs?.model ?? configChannel.model ?? 'claude-sonnet-4.6',
       provider: storedPrefs?.provider ?? null,
@@ -1141,14 +1141,14 @@ export class SessionManager {
         return result.mode;
       } catch { /* fall through to prefs */ }
     }
-    const prefs = getChannelPrefs(channelId);
+    const prefs = await getChannelPrefs(channelId);
     return prefs?.sessionMode ?? 'interactive';
   }
 
   /** Set the session mode (interactive, plan, autopilot). Persists to channel prefs. Does not change yolo/permission state. */
   async setSessionMode(channelId: string, mode: 'interactive' | 'plan' | 'autopilot'): Promise<string> {
     const result = await this.withSessionRetry(channelId, (sid) => this.bridge.setSessionMode(sid, mode));
-    setChannelPrefs(channelId, { sessionMode: result.mode });
+    await setChannelPrefs(channelId, { sessionMode: result.mode });
     return result.mode;
   }
 
@@ -1273,7 +1273,7 @@ export class SessionManager {
   }
 
   /** Resolve a pending permission request (first in queue). */
-  resolvePermission(channelId: string, allow: boolean, remember?: boolean): boolean {
+  async resolvePermission(channelId: string, allow: boolean, remember?: boolean): Promise<boolean> {
     const queue = this.pendingPermissions.get(channelId);
     if (!queue || queue.length === 0) return false;
 
@@ -1283,14 +1283,14 @@ export class SessionManager {
       const action = allow ? 'allow' : 'deny';
       if (pending.serverName) {
         // MCP tool: save at server level so all tools on this server are covered
-        addPermissionRule(channelId, `mcp:${pending.serverName}`, '*', action as 'allow' | 'deny');
+        await addPermissionRule(channelId, `mcp:${pending.serverName}`, '*', action as 'allow' | 'deny');
         log.info(`Saved ${action} rule for MCP server "${pending.serverName}" in channel ${channelId}`);
       } else if (pending.commands.length > 0) {
         for (const cmd of pending.commands) {
-          addPermissionRule(channelId, pending.toolName, cmd, action as 'allow' | 'deny');
+          await addPermissionRule(channelId, pending.toolName, cmd, action as 'allow' | 'deny');
         }
       } else {
-        addPermissionRule(channelId, pending.toolName, '*', action as 'allow' | 'deny');
+        await addPermissionRule(channelId, pending.toolName, '*', action as 'allow' | 'deny');
       }
     }
 
@@ -1375,19 +1375,19 @@ export class SessionManager {
   }
 
   /** Save previous permission mode before auto-enabling yolo. */
-  saveYoloPreviousState(channelId: string): void {
-    const prefs = getChannelPrefs(channelId);
-    const channelConfig = getChannelConfig(channelId);
+  async saveYoloPreviousState(channelId: string): Promise<void> {
+    const prefs = await getChannelPrefs(channelId);
+    const channelConfig = await getChannelConfig(channelId);
     const current = prefs?.permissionMode ?? channelConfig.permissionMode;
     this.yoloPreviousState.set(channelId, current);
   }
 
   /** Revert yolo to previous state (called on session.idle after plan implementation). */
-  revertYoloIfNeeded(channelId: string): boolean {
+  async revertYoloIfNeeded(channelId: string): Promise<boolean> {
     const previous = this.yoloPreviousState.get(channelId);
     if (previous === undefined) return false;
     this.yoloPreviousState.delete(channelId);
-    setChannelPrefs(channelId, { permissionMode: previous });
+    await setChannelPrefs(channelId, { permissionMode: previous });
     return true;
   }
 
@@ -1404,8 +1404,8 @@ export class SessionManager {
   }
 
   /** Get the current session ID for a channel (if any). */
-  getSessionId(channelId: string): string | undefined {
-    return this.channelSessions.get(channelId) ?? getChannelSession(channelId) ?? undefined;
+  async getSessionId(channelId: string): Promise<string | undefined> {
+    return this.channelSessions.get(channelId) ?? await getChannelSession(channelId) ?? undefined;
   }
 
   /** Abort the current turn for a channel's session. */
@@ -1423,10 +1423,10 @@ export class SessionManager {
   }
 
   /** Get info about the current session for a channel. */
-  getSessionInfo(channelId: string): { sessionId: string; model: string; agent: string | null } | null {
+  async getSessionInfo(channelId: string): Promise<{ sessionId: string; model: string; agent: string | null } | null> {
     const sessionId = this.channelSessions.get(channelId);
     if (!sessionId) return null;
-    const prefs = this.getEffectivePrefs(channelId);
+    const prefs = await this.getEffectivePrefs(channelId);
     return { sessionId, model: prefs.model, agent: prefs.agent ?? null };
   }
 
@@ -1439,11 +1439,11 @@ export class SessionManager {
   }
 
   /** Cache the model's max_context_window_tokens for accurate /context display. */
-  private cacheContextWindowTokens(channelId: string, modelId: string, modelList: any[]): void {
+  private async cacheContextWindowTokens(channelId: string, modelId: string, modelList: any[]): Promise<void> {
     let model = modelList.find((m: any) => m.id === modelId);
     // For BYOK models, the merged list has provider-prefixed IDs (e.g., "ollama-local:qwen3:8b")
     if (!model) {
-      const prefs = getChannelPrefs(channelId);
+      const prefs = await getChannelPrefs(channelId);
       if (prefs?.provider) {
         model = modelList.find((m: any) => m.id === `${prefs.provider}:${modelId}`);
       }
@@ -1468,7 +1468,7 @@ export class SessionManager {
 
   /** List past sessions for this channel's working directory. */
   async listChannelSessions(channelId: string): Promise<Array<{ sessionId: string; startTime: Date; modifiedTime: Date; summary?: string; isCurrent: boolean }>> {
-    const workingDirectory = this.resolveWorkingDirectory(channelId);
+    const workingDirectory = await this.resolveWorkingDirectory(channelId);
     const sessions = await this.bridge.listSessions({ cwd: workingDirectory });
     const currentId = this.channelSessions.get(channelId);
     return sessions.map(s => ({
@@ -1483,15 +1483,15 @@ export class SessionManager {
   // --- Private helpers ---
 
   /** Resolve working directory: SQLite workspace override → channel config → default workspace path. */
-  private resolveWorkingDirectory(channelId: string): string {
-    const botName = getChannelBotName(channelId);
-    const override = getWorkspaceOverride(botName);
+  private async resolveWorkingDirectory(channelId: string): Promise<string> {
+    const botName = await getChannelBotName(channelId);
+    const override = await getWorkspaceOverride(botName);
     if (override) return override.workingDirectory;
 
-    const config = getChannelConfig(channelId);
+    const config = await getChannelConfig(channelId);
     if (config.workingDirectory) return config.workingDirectory;
 
-    return getWorkspacePath(botName);
+    return await getWorkspacePath(botName);
   }
 
   /** Build the system message config for session create/resume.
@@ -1529,18 +1529,18 @@ export class SessionManager {
   }
 
   private async createNewSession(channelId: string): Promise<string> {
-    const prefs = this.getEffectivePrefs(channelId);
-    const workingDirectory = this.resolveWorkingDirectory(channelId);
+    const prefs = await this.getEffectivePrefs(channelId);
+    const workingDirectory = await this.resolveWorkingDirectory(channelId);
 
     const defaultConfigDir = process.env.HOME ? `${process.env.HOME}/.copilot` : undefined;
 
     const reasoningEffort = prefs.reasoningEffort as 'low' | 'medium' | 'high' | 'xhigh' | undefined;
     const skillDirectories = discoverSkillDirectories(workingDirectory);
-    const customTools = this.buildCustomTools(channelId);
+    const customTools = await this.buildCustomTools(channelId);
     const disabledSkills = prefs.disabledSkills?.length ? prefs.disabledSkills : undefined;
 
     // Resolve fallback configuration
-    const configChannel = getChannelConfig(channelId);
+    const configChannel = await getChannelConfig(channelId);
     const configFallbacks = configChannel.fallbackModels ?? getConfig().defaults.fallbackModels;
 
     // Resolve BYOK provider if set in prefs
@@ -1628,11 +1628,11 @@ export class SessionManager {
 
     this.sessionMcpServers.set(channelId, new Set(Object.keys(resolvedMcpServers)));
     this.sessionSkillDirs.set(channelId, new Set(skillDirectories));
-    this.cacheContextWindowTokens(channelId, usedModel, modelList);
+    await this.cacheContextWindowTokens(channelId, usedModel, modelList);
 
     if (didFallback) {
       log.info(`Model fallback: "${prefs.model}" → "${usedModel}" for channel ${channelId}`);
-      setChannelPrefs(channelId, { model: usedModel });
+      await setChannelPrefs(channelId, { model: usedModel });
 
       // Emit a user-visible warning via session event
       this.eventHandler?.(session.sessionId, channelId, {
@@ -1646,7 +1646,7 @@ export class SessionManager {
     const sessionId = session.sessionId;
     this.channelSessions.set(channelId, sessionId);
     this.sessionChannels.set(sessionId, channelId);
-    setChannelSession(channelId, sessionId);
+    await setChannelSession(channelId, sessionId);
 
     this.attachSessionEvents(session, channelId);
 
@@ -1655,12 +1655,12 @@ export class SessionManager {
   }
 
   private async attachSession(channelId: string, sessionId: string): Promise<void> {
-    const prefs = this.getEffectivePrefs(channelId);
-    const workingDirectory = this.resolveWorkingDirectory(channelId);
+    const prefs = await this.getEffectivePrefs(channelId);
+    const workingDirectory = await this.resolveWorkingDirectory(channelId);
     const defaultConfigDir = process.env.HOME ? `${process.env.HOME}/.copilot` : undefined;
     const reasoningEffort = prefs.reasoningEffort as 'low' | 'medium' | 'high' | 'xhigh' | undefined;
     const skillDirectories = discoverSkillDirectories(workingDirectory);
-    const customTools = this.buildCustomTools(channelId);
+    const customTools = await this.buildCustomTools(channelId);
     const disabledSkills = prefs.disabledSkills?.length ? prefs.disabledSkills : undefined;
 
     const mcpServers = this.resolveMcpServers(workingDirectory);
@@ -1706,11 +1706,11 @@ export class SessionManager {
 
     // Cache context window tokens for /context display (best-effort, non-blocking)
     const resumeModel = prefs.model;
-    this.bridge.listModels(getConfig().providers).then(models => {
+    this.bridge.listModels(getConfig().providers).then(async (models) => {
       // Guard against model changes before this resolves
-      const currentPrefs = this.getEffectivePrefs(channelId);
+      const currentPrefs = await this.getEffectivePrefs(channelId);
       if (currentPrefs.model === resumeModel) {
-        this.cacheContextWindowTokens(channelId, resumeModel, models);
+        await this.cacheContextWindowTokens(channelId, resumeModel, models);
       }
     }).catch(() => { /* best-effort */ });
   }
@@ -1741,7 +1741,7 @@ export class SessionManager {
     const nextContext = extendContext(opts.context, opts.targetBot);
 
     // Resolve target bot's workspace
-    const targetWorkspace = getWorkspacePath(opts.targetBot);
+    const targetWorkspace = await getWorkspacePath(opts.targetBot);
     const targetBotConfig = this.getTargetBotConfig(opts.targetBot);
 
     // Resolve agent definition
@@ -1752,7 +1752,7 @@ export class SessionManager {
     );
 
     // Build workspace awareness
-    const workspaceMap = getBotWorkspaceMap(opts.targetBot);
+    const workspaceMap = await getBotWorkspaceMap(opts.targetBot);
     const workspacePrompt = buildWorkspacePrompt(workspaceMap);
     const callerPrompt = buildCallerPrompt(opts.context);
 
@@ -1777,7 +1777,7 @@ export class SessionManager {
 
     // Build custom tools for ephemeral session (ask_agent with propagated context)
     // Pass target bot name so chained calls use B's identity (not A's channel)
-    const ephemeralTools = this.buildEphemeralTools(opts.targetBot, nextContext);
+    const ephemeralTools = await this.buildEphemeralTools(opts.targetBot, nextContext);
 
     let session: CopilotSession | undefined;
     try {
@@ -1798,7 +1798,7 @@ export class SessionManager {
       const response = await this.sendAndWaitForIdle(session, opts.message, timeout);
 
       const durationMs = Date.now() - startTime;
-      recordAgentCall({
+      await recordAgentCall({
         callerBot: opts.callerBot,
         targetBot: opts.targetBot,
         targetAgent: opts.agent,
@@ -1816,7 +1816,7 @@ export class SessionManager {
     } catch (err: any) {
       const durationMs = Date.now() - startTime;
       const errorMsg = err?.message ?? 'unknown error';
-      recordAgentCall({
+      await recordAgentCall({
         callerBot: opts.callerBot,
         targetBot: opts.targetBot,
         targetAgent: opts.agent,
@@ -1927,7 +1927,7 @@ export class SessionManager {
         const toolName = (request as any).toolName ?? (request as any).tool_name ?? (request as any).name ?? reqKind;
         if (opts.grantTools.includes(toolName)) {
           // Verify caller has this permission
-          const callerResult = checkPermission(opts.callerChannelId, toolName, '*');
+          const callerResult = await checkPermission(opts.callerChannelId, toolName, '*');
           if (callerResult === 'allow') {
             return { kind: 'approved' };
           }
@@ -1938,12 +1938,12 @@ export class SessionManager {
       // Use a synthetic scope for the target bot
       const targetScope = `bot:${opts.targetBot}`;
       const toolName = (request as any).toolName ?? (request as any).tool_name ?? (request as any).name ?? reqKind;
-      const storedResult = checkPermission(targetScope, toolName, '*');
+      const storedResult = await checkPermission(targetScope, toolName, '*');
       if (storedResult === 'allow') return { kind: 'approved' };
       if (storedResult === 'deny') return { kind: 'denied-by-rules' };
 
       // 6. Caller channel's stored rules (merged — supplement target)
-      const callerResult = checkPermission(opts.callerChannelId, toolName, '*');
+      const callerResult = await checkPermission(opts.callerChannelId, toolName, '*');
       if (callerResult === 'allow') return { kind: 'approved' };
 
       // 7. Autopilot: approve remaining if enabled
@@ -1958,13 +1958,13 @@ export class SessionManager {
   }
 
   /** Build custom tools for an ephemeral inter-agent session. */
-  private buildEphemeralTools(currentBotName: string, context: InterAgentContext): any[] {
+  private async buildEphemeralTools(currentBotName: string, context: InterAgentContext): Promise<any[]> {
     const tools: any[] = [];
     const iaConfig = getInterAgentConfig();
 
     // Only register ask_agent if there's remaining depth
     if (iaConfig.enabled && context.depth < (iaConfig.maxDepth ?? 3)) {
-      tools.push(this.buildAskAgentToolDef(currentBotName, context, true));
+      tools.push(await this.buildAskAgentToolDef(currentBotName, context, true));
     }
 
     return tools;
@@ -1983,8 +1983,8 @@ export class SessionManager {
 
   /** Build the ask_agent tool definition (shared by normal and ephemeral sessions).
    *  When callerBotDirect is true, channelIdOrBot is the bot name directly (for ephemeral sessions). */
-  private buildAskAgentToolDef(channelIdOrBot: string, parentContext?: InterAgentContext, callerBotDirect = false): any {
-    const callerBot = callerBotDirect ? channelIdOrBot : getChannelBotName(channelIdOrBot);
+  private async buildAskAgentToolDef(channelIdOrBot: string, parentContext?: InterAgentContext, callerBotDirect = false): Promise<any> {
+    const callerBot = callerBotDirect ? channelIdOrBot : await getChannelBotName(channelIdOrBot);
     const channelId = callerBotDirect ? undefined : channelIdOrBot;
 
     return {
@@ -2069,15 +2069,15 @@ export class SessionManager {
   }
 
   /** Build custom tool definitions to pass to SDK session creation. */
-  private buildCustomTools(channelId: string): any[] {
+  private async buildCustomTools(channelId: string): Promise<any[]> {
     const tools: any[] = [];
 
     if (this.sendFileHandler) {
       const handler = this.sendFileHandler;
-      const config = getChannelConfig(channelId);
-      const botName = getChannelBotName(channelId);
-      const workDir = this.resolveWorkingDirectory(channelId);
-      const allowPaths = getWorkspaceAllowPaths(botName, config.platform);
+      const config = await getChannelConfig(channelId);
+      const botName = await getChannelBotName(channelId);
+      const workDir = await this.resolveWorkingDirectory(channelId);
+      const allowPaths = await getWorkspaceAllowPaths(botName, config.platform);
 
       tools.push({
         name: 'send_file',
@@ -2121,10 +2121,10 @@ export class SessionManager {
     // Show file contents in chat (renamed from show_file — CLI doesn't support overridesBuiltInTool yet)
     if (this.getAdapterForChannel) {
       const adapterResolver = this.getAdapterForChannel;
-      const showWorkDir = this.resolveWorkingDirectory(channelId);
-      const showBotName = getChannelBotName(channelId);
-      const showConfig = getChannelConfig(channelId);
-      const showAllowPaths = getWorkspaceAllowPaths(showBotName, showConfig.platform);
+      const showWorkDir = await this.resolveWorkingDirectory(channelId);
+      const showBotName = await getChannelBotName(channelId);
+      const showConfig = await getChannelConfig(channelId);
+      const showAllowPaths = await getWorkspaceAllowPaths(showBotName, showConfig.platform);
 
       tools.push({
         name: 'show_file_in_chat',
@@ -2157,7 +2157,7 @@ export class SessionManager {
               return { content: 'File path is outside the allowed workspace.' };
             }
 
-            const adapter = adapterResolver(channelId);
+            const adapter = await adapterResolver(channelId);
             if (!adapter) return { content: 'No adapter available for this channel.' };
 
             const ext = path.extname(realPath).slice(1) || 'txt';
@@ -2210,8 +2210,8 @@ export class SessionManager {
     }
 
     // Admin-only onboarding tools
-    const config = getChannelConfig(channelId);
-    const botName = getChannelBotName(channelId);
+    const config = await getChannelConfig(channelId);
+    const botName = await getChannelBotName(channelId);
     const isAdmin = isBotAdmin(config.platform, botName);
 
     if (isAdmin && this.getAdapterForChannel) {
@@ -2224,7 +2224,7 @@ export class SessionManager {
         parameters: { type: 'object', properties: {} },
         handler: async () => {
           try {
-            const adapter = adapterResolver(channelId);
+            const adapter = await adapterResolver(channelId);
             if (!adapter?.getTeams) return { content: 'Platform does not support team listing.' };
 
             const teams = await adapter.getTeams();
@@ -2280,7 +2280,7 @@ export class SessionManager {
           threaded_replies: boolean;
         }) => {
           try {
-            const adapter = adapterResolver(channelId);
+            const adapter = await adapterResolver(channelId);
             if (!adapter) return { content: 'Error: No adapter available for this channel.' };
 
             const result = await onboardProject(adapter, {
@@ -2327,8 +2327,8 @@ export class SessionManager {
         },
         handler: async (args: { bot_name: string; path: string }) => {
           try {
-            const existing = getWorkspaceOverride(args.bot_name);
-            const workDir = existing?.workingDirectory ?? getWorkspacePath(args.bot_name);
+            const existing = await getWorkspaceOverride(args.bot_name);
+            const workDir = existing?.workingDirectory ?? await getWorkspacePath(args.bot_name);
             const currentPaths = existing?.allowPaths ?? [];
             const resolvedPath = path.resolve(args.path);
 
@@ -2349,7 +2349,7 @@ export class SessionManager {
               return { content: `"${args.bot_name}" already has access to ${resolvedPath}.` };
             }
             const newPaths = [...currentPaths, resolvedPath];
-            setWorkspaceOverride(args.bot_name, workDir, newPaths);
+            await setWorkspaceOverride(args.bot_name, workDir, newPaths);
             return {
               content: `✅ Granted "${args.bot_name}" access to ${resolvedPath}.\nCurrent allowed paths: ${JSON.stringify(newPaths)}\n\nTo apply: delete the agent's AGENTS.md and run /new in its channel (or restart the bridge).`,
             };
@@ -2373,11 +2373,11 @@ export class SessionManager {
         },
         handler: async (args: { bot_name: string; path: string }) => {
           try {
-            const existing = getWorkspaceOverride(args.bot_name);
+            const existing = await getWorkspaceOverride(args.bot_name);
             if (!existing) return { content: `No workspace override found for "${args.bot_name}".` };
             const resolvedPath = path.resolve(args.path);
             const newPaths = existing.allowPaths.filter(p => path.resolve(p) !== resolvedPath);
-            setWorkspaceOverride(args.bot_name, existing.workingDirectory, newPaths);
+            await setWorkspaceOverride(args.bot_name, existing.workingDirectory, newPaths);
             return {
               content: `✅ Revoked "${args.bot_name}" access to ${resolvedPath}.\nRemaining allowed paths: ${JSON.stringify(newPaths)}\n\nTo apply: delete the agent's AGENTS.md and run /new in its channel (or restart the bridge).`,
             };
@@ -2394,7 +2394,7 @@ export class SessionManager {
         parameters: { type: 'object', properties: {} },
         handler: async () => {
           try {
-            const overrides = listWorkspaceOverrides();
+            const overrides = await listWorkspaceOverrides();
             const overrideMap = new Map(overrides.map(o => [o.botName, o]));
 
             // Enumerate all configured bots across platforms
@@ -2410,12 +2410,12 @@ export class SessionManager {
 
             if (botNames.size === 0) return { content: 'No agents configured.' };
 
-            const lines = [...botNames].sort().map(name => {
+            const lines = await Promise.all([...botNames].sort().map(async (name) => {
               const override = overrideMap.get(name);
-              const workspace = override?.workingDirectory ?? getWorkspacePath(name);
+              const workspace = override?.workingDirectory ?? await getWorkspacePath(name);
               const extra = override?.allowPaths ?? [];
               return `**${name}**\n  Workspace: ${workspace}\n  Extra paths: ${extra.length > 0 ? extra.join(', ') : '(none)'}`;
-            });
+            }));
             return { content: lines.join('\n\n') };
           } catch (err: any) {
             return { content: `Failed: ${err?.message ?? 'unknown error'}` };
@@ -2427,14 +2427,14 @@ export class SessionManager {
     // Inter-agent tool: ask_agent (only when enabled in config)
     const iaConfig = getInterAgentConfig();
     if (iaConfig.enabled) {
-      tools.push(this.buildAskAgentToolDef(channelId));
+      tools.push(await this.buildAskAgentToolDef(channelId));
     }
 
     // Scheduler tool: create/list/cancel/pause/resume scheduled tasks
-    tools.push(this.buildScheduleToolDef(channelId));
+    tools.push(await this.buildScheduleToolDef(channelId));
 
     // Bridge documentation tool
-    tools.push(this.buildBridgeDocsTool(channelId));
+    tools.push(await this.buildBridgeDocsTool(channelId));
 
     // No-reply tool: agent calls this instead of emitting "NO_REPLY" text
     tools.push({
@@ -2465,8 +2465,8 @@ export class SessionManager {
   }
 
   /** Build the schedule tool definition for creating/managing scheduled tasks. */
-  private buildScheduleToolDef(channelId: string): any {
-    const botName = getChannelBotName(channelId);
+  private async buildScheduleToolDef(channelId: string): Promise<any> {
+    const botName = await getChannelBotName(channelId);
 
     return {
       name: 'schedule',
@@ -2520,7 +2520,7 @@ export class SessionManager {
             case 'create': {
               if (!args.prompt) return { content: 'Error: prompt is required for create.' };
               if (!args.cron && !args.run_at) return { content: 'Error: either cron or run_at is required.' };
-              const task = addJob({
+              const task = await addJob({
                 channelId,
                 botName,
                 prompt: args.prompt,
@@ -2536,7 +2536,7 @@ export class SessionManager {
               return { content: JSON.stringify({ success: true, id: task.id, type, nextRun: nextRunLocal, timezone: tz, description: task.description }) };
             }
             case 'list': {
-              const tasks = listJobs(channelId);
+              const tasks = await listJobs(channelId);
               if (tasks.length === 0) return { content: 'No scheduled tasks for this channel.' };
               const summary = tasks.map(t => {
                 const tz = t.timezone ?? 'UTC';
@@ -2555,17 +2555,17 @@ export class SessionManager {
             }
             case 'cancel': {
               if (!args.id) return { content: 'Error: id is required for cancel.' };
-              const removed = removeJob(args.id, channelId);
+              const removed = await removeJob(args.id, channelId);
               return { content: removed ? `Task ${args.id} cancelled and removed.` : `Task ${args.id} not found.` };
             }
             case 'pause': {
               if (!args.id) return { content: 'Error: id is required for pause.' };
-              const paused = pauseJob(args.id, channelId);
+              const paused = await pauseJob(args.id, channelId);
               return { content: paused ? `Task ${args.id} paused.` : `Task ${args.id} not found.` };
             }
             case 'resume': {
               if (!args.id) return { content: 'Error: id is required for resume.' };
-              const resumed = resumeJob(args.id, channelId);
+              const resumed = await resumeJob(args.id, channelId);
               return { content: resumed ? `Task ${args.id} resumed.` : `Task ${args.id} not found or failed to resume.` };
             }
             default:
@@ -2578,9 +2578,9 @@ export class SessionManager {
     };
   }
 
-  private buildBridgeDocsTool(channelId: string): any {
-    const channelConfig = getChannelConfig(channelId);
-    const botName = getChannelBotName(channelId);
+  private async buildBridgeDocsTool(channelId: string): Promise<any> {
+    const channelConfig = await getChannelConfig(channelId);
+    const botName = await getChannelBotName(channelId);
     const isAdmin = isBotAdmin(channelConfig.platform, botName);
 
     return {
@@ -2598,7 +2598,7 @@ export class SessionManager {
         required: [],
       },
       handler: async (args: { topic?: string }) => {
-        const sessionInfo = this.getSessionInfo(channelId);
+        const sessionInfo = await this.getSessionInfo(channelId);
         return {
           content: getBridgeDocs({
             topic: args.topic,
@@ -2625,12 +2625,12 @@ export class SessionManager {
     this.sessionUnsubscribes.set(session.sessionId, unsub);
   }
 
-  private handlePermissionRequest(
+  private async handlePermissionRequest(
     channelId: string,
     request: any,
     invocation: { sessionId: string },
   ): Promise<any> {
-    const prefs = this.getEffectivePrefs(channelId);
+    const prefs = await this.getEffectivePrefs(channelId);
 
     // Hardcoded safety denies — checked before autopilot, cannot be overridden
     const reqKind = (request as any).kind;
@@ -2654,10 +2654,10 @@ export class SessionManager {
     }
 
     // Check config-level permission rules first (CLI-compatible syntax)
-    const config = getChannelConfig(channelId);
-    const botName = getChannelBotName(channelId);
-    const resolvedDir = this.resolveWorkingDirectory(channelId);
-    const workspaceAllowPaths = getWorkspaceAllowPaths(botName, config.platform);
+    const config = await getChannelConfig(channelId);
+    const botName = await getChannelBotName(channelId);
+    const resolvedDir = await this.resolveWorkingDirectory(channelId);
+    const workspaceAllowPaths = await getWorkspaceAllowPaths(botName, config.platform);
     const configResult = evaluateConfigPermissions(request as any, resolvedDir, workspaceAllowPaths, isBotAdmin(config.platform, botName));
     if (configResult === 'allow') {
       return Promise.resolve({ kind: 'approved' });
@@ -2677,7 +2677,7 @@ export class SessionManager {
 
     // For MCP tools, check server-level rules first (covers all tools on that server)
     if (kind === 'mcp' && serverName) {
-      const serverResult = checkPermission(channelId, `mcp:${serverName}`, '*');
+      const serverResult = await checkPermission(channelId, `mcp:${serverName}`, '*');
       if (serverResult === 'allow') {
         log.debug(`MCP "${serverName}" auto-approved by stored rule`);
         return Promise.resolve({ kind: 'approved' });
@@ -2689,7 +2689,7 @@ export class SessionManager {
     }
 
     if (commands.length > 0) {
-      const results = commands.map(cmd => checkPermission(channelId, toolName, cmd));
+      const results = await Promise.all(commands.map(cmd => checkPermission(channelId, toolName, cmd)));
       if (results.every(r => r === 'allow')) {
         const hasWrapper = commands.some(cmd => SHELL_WRAPPERS.has(cmd));
         if (!hasWrapper) {
@@ -2700,7 +2700,7 @@ export class SessionManager {
         return Promise.resolve({ kind: 'denied-by-rules' });
       }
     } else {
-      const result = checkPermission(channelId, toolName, '*');
+      const result = await checkPermission(channelId, toolName, '*');
       if (result === 'allow') return Promise.resolve({ kind: 'approved' });
       if (result === 'deny') return Promise.resolve({ kind: 'denied-by-rules' });
     }

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1395,8 +1395,13 @@ export class SessionManager {
     const previous = this.yoloPreviousState.get(channelId);
     if (previous === undefined) return false;
     this.yoloPreviousState.delete(channelId);
-    await setChannelPrefs(channelId, { permissionMode: previous });
-    return true;
+    try {
+      await setChannelPrefs(channelId, { permissionMode: previous });
+      return true;
+    } catch (err) {
+      log.warn(`Failed to revert yolo permissionMode for ${channelId.slice(0, 8)}...:`, err);
+      return false;
+    }
   }
 
   /** Debounced plan change handler — calls callback after debounce window. */

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -639,7 +639,7 @@ export class SessionManager {
         return { sessionId: storedSessionId, isNew: false };
       } catch (err) {
       log.warn(`Failed to resume session ${storedSessionId} for channel ${channelId}, creating new:`, err);
-        await clearChannelSession(channelId);
+        try { await clearChannelSession(channelId); } catch (e) { log.warn('Failed to clear channel session during recovery:', e); }
       }
     }
 
@@ -836,7 +836,7 @@ export class SessionManager {
         }
 
         // If no fallback worked, restore original model pref and throw
-        await setChannelPrefs(channelId, { model: prefs.model });
+        try { await setChannelPrefs(channelId, { model: prefs.model }); } catch (e) { log.warn('Failed to restore model pref after fallback failure:', e); }
         throw lastError;
       }
 
@@ -926,7 +926,7 @@ export class SessionManager {
           // Clear stale session so ensureSession() creates fresh on next call
           this.channelSessions.delete(channelId);
           this.sessionChannels.delete(sessionId);
-          await clearChannelSession(channelId);
+          try { await clearChannelSession(channelId); } catch (e) { log.warn('Failed to clear channel session during retry recovery:', e); }
           throw err;
         }
         // Last resort: new session
@@ -1028,7 +1028,7 @@ export class SessionManager {
         await this.newSession(channelId);
       } catch (err) {
         log.warn(`Provider switch failed, reverting prefs:`, err);
-        await setChannelPrefs(channelId, { model: prevModel, provider: currentProvider });
+        try { await setChannelPrefs(channelId, { model: prevModel, provider: currentProvider }); } catch (e) { log.warn('Failed to revert prefs after provider switch failure:', e); }
         throw err;
       }
     } else if (newProvider && this.wireApiChanged(newProvider, currentPrefs.model ?? '', model)) {
@@ -1040,7 +1040,7 @@ export class SessionManager {
         await this.newSession(channelId);
       } catch (err) {
         log.warn(`wireApi switch failed, reverting prefs:`, err);
-        await setChannelPrefs(channelId, { model: prevModel, provider: currentProvider });
+        try { await setChannelPrefs(channelId, { model: prevModel, provider: currentProvider }); } catch (e) { log.warn('Failed to revert prefs after wireApi switch failure:', e); }
         throw err;
       }
     } else {
@@ -1816,17 +1816,19 @@ export class SessionManager {
     } catch (err: any) {
       const durationMs = Date.now() - startTime;
       const errorMsg = err?.message ?? 'unknown error';
-      await recordAgentCall({
-        callerBot: opts.callerBot,
-        targetBot: opts.targetBot,
-        targetAgent: opts.agent,
-        messageSummary: opts.message.slice(0, 500),
-        durationMs,
-        success: false,
-        error: errorMsg,
-        chainId: opts.context.chainId,
-        depth: nextContext.depth,
-      });
+      try {
+        await recordAgentCall({
+          callerBot: opts.callerBot,
+          targetBot: opts.targetBot,
+          targetAgent: opts.agent,
+          messageSummary: opts.message.slice(0, 500),
+          durationMs,
+          success: false,
+          error: errorMsg,
+          chainId: opts.context.chainId,
+          depth: nextContext.depth,
+        });
+      } catch (e) { log.warn('Failed to record agent call during error handling:', e); }
 
       log.error(`Ephemeral call ${opts.callerBot}→${opts.targetBot} failed: ${errorMsg}`);
       return { success: false, error: 'ephemeral_session_error', detail: errorMsg };
@@ -2675,6 +2677,8 @@ export class SessionManager {
     const toolInput = request.input ?? (request as any).arguments ?? (request as any).parameters ?? request;
     const commands = extractCommandPatterns(toolInput);
 
+    // Check stored permission rules (DB errors fall through to interactive prompt)
+    try {
     // For MCP tools, check server-level rules first (covers all tools on that server)
     if (kind === 'mcp' && serverName) {
       const serverResult = await checkPermission(channelId, `mcp:${serverName}`, '*');
@@ -2703,6 +2707,9 @@ export class SessionManager {
       const result = await checkPermission(channelId, toolName, '*');
       if (result === 'allow') return Promise.resolve({ kind: 'approved' });
       if (result === 'deny') return Promise.resolve({ kind: 'denied-by-rules' });
+    }
+    } catch (err) {
+      log.warn('Permission check failed, falling through to interactive:', err);
     }
 
     // No rule matched — need to ask the user via chat

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1046,7 +1046,8 @@ export class SessionManager {
     } else {
       // Same provider — use RPC model switch (with session retry)
       await this.withSessionRetry(channelId, (sid) => this.bridge.switchSessionModel(sid, model));
-      await setChannelPrefs(channelId, { model, provider: newProvider });
+      try { await setChannelPrefs(channelId, { model, provider: newProvider }); }
+      catch (e) { log.warn('Model switched but failed to persist preference:', e); }
     }
 
     // Clear stale context window tokens so /context falls back to tokenLimit during transition
@@ -1084,7 +1085,8 @@ export class SessionManager {
         await this.bridge.deselectAgent(sid);
       }
     });
-    await setChannelPrefs(channelId, { agent });
+    try { await setChannelPrefs(channelId, { agent }); }
+    catch (e) { log.warn('Agent switched but failed to persist preference:', e); }
   }
 
   /**
@@ -1097,7 +1099,8 @@ export class SessionManager {
     await this.withSessionRetry(channelId, (sid) =>
       this.bridge.switchSessionModel(sid, model, { reasoningEffort: effort })
     );
-    await setChannelPrefs(channelId, { reasoningEffort: effort });
+    try { await setChannelPrefs(channelId, { reasoningEffort: effort }); }
+    catch (e) { log.warn('Reasoning effort set but failed to persist preference:', e); }
   }
 
   /** Get effective preferences for a channel (config merged with runtime overrides). */
@@ -1148,7 +1151,8 @@ export class SessionManager {
   /** Set the session mode (interactive, plan, autopilot). Persists to channel prefs. Does not change yolo/permission state. */
   async setSessionMode(channelId: string, mode: 'interactive' | 'plan' | 'autopilot'): Promise<string> {
     const result = await this.withSessionRetry(channelId, (sid) => this.bridge.setSessionMode(sid, mode));
-    await setChannelPrefs(channelId, { sessionMode: result.mode });
+    try { await setChannelPrefs(channelId, { sessionMode: result.mode }); }
+    catch (e) { log.warn('Session mode set but failed to persist preference:', e); }
     return result.mode;
   }
 
@@ -1279,24 +1283,28 @@ export class SessionManager {
 
     const pending = queue.shift()!;
 
-    if (remember && !pending.fromHook) {
-      const action = allow ? 'allow' : 'deny';
-      if (pending.serverName) {
-        // MCP tool: save at server level so all tools on this server are covered
-        await addPermissionRule(channelId, `mcp:${pending.serverName}`, '*', action as 'allow' | 'deny');
-        log.info(`Saved ${action} rule for MCP server "${pending.serverName}" in channel ${channelId}`);
-      } else if (pending.commands.length > 0) {
-        for (const cmd of pending.commands) {
-          await addPermissionRule(channelId, pending.toolName, cmd, action as 'allow' | 'deny');
-        }
-      } else {
-        await addPermissionRule(channelId, pending.toolName, '*', action as 'allow' | 'deny');
-      }
-    }
-
+    // Resolve the permission first — don't let persistence failures block the SDK callback
     pending.resolve(allow
       ? { kind: 'approved' }
       : { kind: 'denied-interactively-by-user' });
+
+    if (remember && !pending.fromHook) {
+      const action = allow ? 'allow' : 'deny';
+      try {
+        if (pending.serverName) {
+          await addPermissionRule(channelId, `mcp:${pending.serverName}`, '*', action as 'allow' | 'deny');
+          log.info(`Saved ${action} rule for MCP server "${pending.serverName}" in channel ${channelId}`);
+        } else if (pending.commands.length > 0) {
+          for (const cmd of pending.commands) {
+            await addPermissionRule(channelId, pending.toolName, cmd, action as 'allow' | 'deny');
+          }
+        } else {
+          await addPermissionRule(channelId, pending.toolName, '*', action as 'allow' | 'deny');
+        }
+      } catch (err) {
+        log.warn('Failed to persist permission rule (permission was still applied):', err);
+      }
+    }
 
     if (queue.length === 0) {
       this.pendingPermissions.delete(channelId);
@@ -1798,17 +1806,19 @@ export class SessionManager {
       const response = await this.sendAndWaitForIdle(session, opts.message, timeout);
 
       const durationMs = Date.now() - startTime;
-      await recordAgentCall({
-        callerBot: opts.callerBot,
-        targetBot: opts.targetBot,
-        targetAgent: opts.agent,
-        messageSummary: opts.message.slice(0, 500),
-        responseSummary: response.slice(0, 500),
-        durationMs,
-        success: true,
-        chainId: opts.context.chainId,
-        depth: nextContext.depth,
-      });
+      try {
+        await recordAgentCall({
+          callerBot: opts.callerBot,
+          targetBot: opts.targetBot,
+          targetAgent: opts.agent,
+          messageSummary: opts.message.slice(0, 500),
+          responseSummary: response.slice(0, 500),
+          durationMs,
+          success: true,
+          chainId: opts.context.chainId,
+          depth: nextContext.depth,
+        });
+      } catch (e) { log.warn('Failed to record successful agent call:', e); }
 
       log.info(`Ephemeral call ${opts.callerBot}→${opts.targetBot}: ${durationMs}ms, ${response.length} chars`);
       return { success: true, response };

--- a/src/core/workspace-manager.ts
+++ b/src/core/workspace-manager.ts
@@ -51,17 +51,17 @@ function validateBotName(name: string): void {
   }
 }
 
-export function getWorkspacePath(botName: string): string {
+export async function getWorkspacePath(botName: string): Promise<string> {
   validateBotName(botName);
-  const override = getWorkspaceOverride(botName);
+  const override = await getWorkspaceOverride(botName);
   if (override) {
     return override.workingDirectory;
   }
   return path.join(WORKSPACES_DIR, botName);
 }
 
-export function getWorkspaceAllowPaths(botName: string, platformName?: string): string[] {
-  const override = getWorkspaceOverride(botName);
+export async function getWorkspaceAllowPaths(botName: string, platformName?: string): Promise<string[]> {
+  const override = await getWorkspaceOverride(botName);
   let paths = override?.allowPaths ?? [];
 
   // Admin bots automatically get access to the workspaces directory and config home
@@ -75,8 +75,8 @@ export function getWorkspaceAllowPaths(botName: string, platformName?: string): 
   return paths;
 }
 
-export function initWorkspace(botName: string, overridePath?: string, adminOverride?: boolean): string {
-  const workspacePath = overridePath ?? getWorkspacePath(botName);
+export async function initWorkspace(botName: string, overridePath?: string, adminOverride?: boolean): Promise<string> {
+  const workspacePath = overridePath ?? await getWorkspacePath(botName);
   if (!fs.existsSync(workspacePath)) {
     fs.mkdirSync(workspacePath, { recursive: true });
   }
@@ -85,7 +85,7 @@ export function initWorkspace(botName: string, overridePath?: string, adminOverr
 
   const agentsFile = path.join(workspacePath, 'AGENTS.md');
   if (!fs.existsSync(agentsFile)) {
-    const allowPaths = admin ? getWorkspaceAllowPaths(botName) : (getWorkspaceOverride(botName)?.allowPaths ?? []);
+    const allowPaths = admin ? await getWorkspaceAllowPaths(botName) : ((await getWorkspaceOverride(botName))?.allowPaths ?? []);
     fs.writeFileSync(agentsFile, generateAgentsTemplate(botName, workspacePath, allowPaths, admin), 'utf-8');
   }
 
@@ -101,7 +101,7 @@ export function initWorkspace(botName: string, overridePath?: string, adminOverr
   return workspacePath;
 }
 
-export function listWorkspaces(): Array<{ botName: string; path: string; isOverride: boolean; allowPaths: string[] }> {
+export async function listWorkspaces(): Promise<Array<{ botName: string; path: string; isOverride: boolean; allowPaths: string[] }>> {
   const results = new Map<string, { botName: string; path: string; isOverride: boolean; allowPaths: string[] }>();
 
   // Scan filesystem
@@ -119,7 +119,7 @@ export function listWorkspaces(): Array<{ botName: string; path: string; isOverr
   }
 
   // Merge SQLite overrides
-  for (const override of listWorkspaceOverrides()) {
+  for (const override of await listWorkspaceOverrides()) {
     results.set(override.botName, {
       botName: override.botName,
       path: override.workingDirectory,

--- a/src/index.ts
+++ b/src/index.ts
@@ -584,7 +584,7 @@ async function main(): Promise<void> {
   log.info('copilot-bridge ready!');
 
   // Initialize scheduler — rehydrate persisted jobs
-  initScheduler({
+  await initScheduler({
     sendMessage: async (channelId, prompt) => {
       // Route through channelLocks to serialize with user messages
       const prev = channelLocks.get(channelId) ?? Promise.resolve();
@@ -640,7 +640,7 @@ async function main(): Promise<void> {
   });
 
   // Post restart notice to admin DM channels (no session creation needed)
-  postRestartNotices();
+  void postRestartNotices().catch((err) => log.error('postRestartNotices failed:', err));
 
   // Graceful shutdown
   const shutdown = async () => {
@@ -783,7 +783,7 @@ async function handleMidTurnMessage(
       await finalizeActivityFeed(msg.channelId, adapter);
       await sessionManager.abortSession(msg.channelId);
       // Revert yolo if temporarily enabled for plan implementation
-      sessionManager.revertYoloIfNeeded(msg.channelId);
+      await sessionManager.revertYoloIfNeeded(msg.channelId);
       markIdleImmediate(msg.channelId);
       await adapter.sendMessage(msg.channelId, '🛑 Task stopped.', { threadRootId: threadRoot });
       return;
@@ -1362,6 +1362,7 @@ async function handleInboundMessage(
         break;
       }
       case 'schedule': {
+        try {
         const args = cmdResult.payload as string | undefined;
         const sub = args?.split(/\s+/)?.[0]?.toLowerCase();
         const subArg = args?.slice((sub?.length ?? 0)).trim();
@@ -1422,6 +1423,10 @@ async function handleInboundMessage(
           }
         } else {
           await adapter.sendMessage(msg.channelId, '⚠️ Usage: `/schedule [list|cancel|pause|resume|history] [id]`', { threadRootId: threadRoot });
+        }
+        } catch (err: any) {
+          log.error(`Schedule command failed:`, err);
+          await adapter.sendMessage(msg.channelId, '❌ Schedule command failed — database error.', { threadRootId: threadRoot });
         }
         break;
       }
@@ -1494,6 +1499,7 @@ async function handleInboundMessage(
       }
 
       case 'skill_toggle': {
+        try {
         const { action: toggleAction, targets } = cmdResult.payload as { action: 'enable' | 'disable'; targets: string[] };
         const skills = await sessionManager.getSkillInfo(msg.channelId);
         const prefs = await getChannelPrefs(msg.channelId);
@@ -1571,6 +1577,10 @@ async function handleInboundMessage(
           lines.push(`❌ No match: ${notFound.map(n => `"${n}"`).join(', ')}`);
         }
         await adapter.sendMessage(msg.channelId, lines.join(' '), { threadRootId: threadRoot });
+        } catch (err: any) {
+          log.error(`Skill toggle failed:`, err);
+          await adapter.sendMessage(msg.channelId, '❌ Skill command failed — database error.', { threadRootId: threadRoot });
+        }
         break;
       }
 
@@ -1758,7 +1768,7 @@ async function handleInboundMessage(
           await sessionManager.sendMessage(msg.channelId, kickoff);
           await waitForChannelIdle(msg.channelId);
         } catch (err: any) {
-          sessionManager.revertYoloIfNeeded(msg.channelId);
+          await sessionManager.revertYoloIfNeeded(msg.channelId);
           markIdleImmediate(msg.channelId);
           const sk = activeStreams.get(msg.channelId);
           if (sk) { await streaming.cancelStream(sk); activeStreams.delete(msg.channelId); }
@@ -2001,7 +2011,12 @@ async function handleSessionEvent(
   const { adapter, streaming } = resolved;
 
   const channelConfig = await getChannelConfig(channelId);
-  const prefs = await getChannelPrefs(channelId);
+  let prefs: Awaited<ReturnType<typeof getChannelPrefs>> = null;
+  try {
+    prefs = await getChannelPrefs(channelId);
+  } catch (err) {
+    log.warn('Failed to read channel prefs in event handler, using defaults:', err);
+  }
   const verbose = prefs?.verbose ?? channelConfig.verbose;
 
   // Handle custom bridge events (permissions, user input)

--- a/src/index.ts
+++ b/src/index.ts
@@ -656,7 +656,7 @@ async function main(): Promise<void> {
       await streaming.cleanup();
     }
     await bridge.stop();
-    await closeDb();
+    try { await closeDb(); } catch (err) { log.warn('Failed to close database during shutdown:', err); }
     log.info('Goodbye.');
     process.exit(0);
   };
@@ -2413,8 +2413,12 @@ async function handleSessionEvent(
           activeStreams.delete(channelId);
         }
         // Revert yolo if it was temporarily enabled for plan implementation
-        if (await sessionManager.revertYoloIfNeeded(channelId)) {
-          log.info(`Reverted yolo state on idle for ${channelId.slice(0, 8)}...`);
+        try {
+          if (await sessionManager.revertYoloIfNeeded(channelId)) {
+            log.info(`Reverted yolo state on idle for ${channelId.slice(0, 8)}...`);
+          }
+        } catch (err) {
+          log.warn(`Failed to revert yolo state on idle for ${channelId.slice(0, 8)}...:`, err);
         }
         // Clean up temp files from downloaded attachments
         void cleanupTempFiles(channelId).catch(() => { /* best-effort */ });
@@ -2497,6 +2501,6 @@ async function postRestartNotices(): Promise<void> {
 // Start the bridge
 main().catch(async (err) => {
   log.error('Fatal error:', err);
-  await closeDb();
+  try { await closeDb(); } catch { /* best-effort */ }
   process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,8 +168,8 @@ async function downloadAttachments(
 ): Promise<Array<{ type: 'file'; path: string; displayName?: string }>> {
   if (!attachments || attachments.length === 0) return [];
 
-  const botName = getChannelBotName(channelId);
-  const workspace = getWorkspacePath(botName);
+  const botName = await getChannelBotName(channelId);
+  const workspace = await getWorkspacePath(botName);
   const tempDir = path.join(workspace, '.temp', channelId);
 
   const results: Array<{ type: 'file'; path: string; displayName?: string }> = [];
@@ -193,10 +193,10 @@ async function downloadAttachments(
 }
 
 /** Remove temp files for a specific channel's temp directory. */
-function cleanupTempFiles(channelId: string): void {
+async function cleanupTempFiles(channelId: string): Promise<void> {
   try {
-    const botName = getChannelBotName(channelId);
-    const tempDir = path.join(getWorkspacePath(botName), '.temp', channelId);
+    const botName = await getChannelBotName(channelId);
+    const tempDir = path.join(await getWorkspacePath(botName), '.temp', channelId);
     if (!fs.existsSync(tempDir)) return;
 
     const files = fs.readdirSync(tempDir);
@@ -213,9 +213,9 @@ function cleanupTempFiles(channelId: string): void {
   } catch { /* best effort */ }
 }
 
-function getAdapterForChannel(channelId: string): { adapter: ChannelAdapter; streaming: StreamingHandler } | null {
-  const channelConfig = getChannelConfig(channelId);
-  const botName = getChannelBotName(channelId);
+async function getAdapterForChannel(channelId: string): Promise<{ adapter: ChannelAdapter; streaming: StreamingHandler } | null> {
+  const channelConfig = await getChannelConfig(channelId);
+  const botName = await getChannelBotName(channelId);
   const key = `${channelConfig.platform}:${botName}`;
   const adapter = botAdapters.get(key);
   const streaming = botStreamers.get(key);
@@ -419,19 +419,21 @@ async function main(): Promise<void> {
   for (const [platformName] of Object.entries(config.platforms)) {
     const bots = getPlatformBots(platformName);
     for (const [botName] of bots) {
-      initWorkspace(botName);
+      await initWorkspace(botName);
     }
   }
 
   // Watch for new workspace directories
   const workspaceWatcher = new WorkspaceWatcher();
   workspaceWatcher.onEvent((event) => {
-    if (event.type === 'created') {
-      initWorkspace(event.botName);
-      log.info(`Workspace ready for "${event.botName}" — channel registration will occur on first message`);
-    } else if (event.type === 'removed') {
-      log.warn(`Workspace removed for "${event.botName}" — existing sessions will continue but workspace files are gone`);
-    }
+    void (async () => {
+      if (event.type === 'created') {
+        await initWorkspace(event.botName);
+        log.info(`Workspace ready for "${event.botName}" — channel registration will occur on first message`);
+      } else if (event.type === 'removed') {
+        log.warn(`Workspace removed for "${event.botName}" — existing sessions will continue but workspace files are gone`);
+      }
+    })().catch((err) => log.error('Workspace event handler error:', err));
   });
   workspaceWatcher.start();
 
@@ -494,7 +496,7 @@ async function main(): Promise<void> {
 
   // Wire up send_file tool → adapter.sendFile (with thread context)
   sessionManager.onSendFile(async (channelId, filePath, message) => {
-    const resolved = getAdapterForChannel(channelId);
+    const resolved = await getAdapterForChannel(channelId);
     if (!resolved) throw new Error('No adapter for channel');
     // Preserve thread context if threaded replies are active
     const streamKey = activeStreams.get(channelId);
@@ -503,8 +505,8 @@ async function main(): Promise<void> {
   });
 
   // Provide adapter resolver for onboarding tools
-  sessionManager.onGetAdapter((channelId) => {
-    const resolved = getAdapterForChannel(channelId);
+  sessionManager.onGetAdapter(async (channelId) => {
+    const resolved = await getAdapterForChannel(channelId);
     return resolved?.adapter ?? null;
   });
 
@@ -554,9 +556,9 @@ async function main(): Promise<void> {
       const dmChannels = await adapter.discoverDMChannels();
       let registered = 0;
       for (const dm of dmChannels) {
-        if (!isConfiguredChannel(dm.channelId)) {
-          const workspacePath = getWorkspacePath(botName);
-          initWorkspace(botName);
+        if (!await isConfiguredChannel(dm.channelId)) {
+          const workspacePath = await getWorkspacePath(botName);
+          await initWorkspace(botName);
           registerDynamicChannel({
             id: dm.channelId,
             platform: platformName,
@@ -587,7 +589,7 @@ async function main(): Promise<void> {
       // Route through channelLocks to serialize with user messages
       const prev = channelLocks.get(channelId) ?? Promise.resolve();
       const task = prev.then(async () => {
-        const resolved = getAdapterForChannel(channelId);
+        const resolved = await getAdapterForChannel(channelId);
         if (resolved) {
           const { streaming } = resolved;
           // Finalize any existing stream, but don't create a new one —
@@ -616,7 +618,7 @@ async function main(): Promise<void> {
           markIdleImmediate(channelId);
           const failedStream = activeStreams.get(channelId);
           if (failedStream) {
-            const r = getAdapterForChannel(channelId);
+            const r = await getAdapterForChannel(channelId);
             if (r) await r.streaming.cancelStream(failedStream, err?.message ?? 'Scheduled job failed').catch(() => {});
             activeStreams.delete(channelId);
           }
@@ -630,7 +632,7 @@ async function main(): Promise<void> {
       return '';
     },
     postMessage: async (channelId, text) => {
-      const resolved = getAdapterForChannel(channelId);
+      const resolved = await getAdapterForChannel(channelId);
       if (resolved) {
         await resolved.adapter.sendMessage(channelId, text);
       }
@@ -654,7 +656,7 @@ async function main(): Promise<void> {
       await streaming.cleanup();
     }
     await bridge.stop();
-    closeDb();
+    await closeDb();
     log.info('Goodbye.');
     process.exit(0);
   };
@@ -693,16 +695,16 @@ async function handleMidTurnMessage(
     return;
   }
 
-  if (!isConfiguredChannel(msg.channelId)) return;
+  if (!await isConfiguredChannel(msg.channelId)) return;
 
-  const assignedBot = getChannelBotName(msg.channelId);
+  const assignedBot = await getChannelBotName(msg.channelId);
   if (assignedBot && assignedBot !== botName) return;
 
-  const resolved = getAdapterForChannel(msg.channelId);
+  const resolved = await getAdapterForChannel(msg.channelId);
   if (!resolved) return;
   const { adapter } = resolved;
 
-  const channelConfig = getChannelConfig(msg.channelId);
+  const channelConfig = await getChannelConfig(msg.channelId);
 
   // Respect trigger mode — don't steer on unmentioned messages in mention-only channels
   if (channelConfig.triggerMode === 'mention' && !msg.mentionsBot && !msg.isDM) {
@@ -726,32 +728,32 @@ async function handleMidTurnMessage(
   if (sessionManager.hasPendingPermission(msg.channelId)) {
     const lower = text.toLowerCase();
     if (lower === '/approve' || lower === 'yes' || lower === 'y' || lower === 'approve') {
-      sessionManager.resolvePermission(msg.channelId, true);
+      await sessionManager.resolvePermission(msg.channelId, true);
       return;
     }
     if (lower === '/deny' || lower === 'no' || lower === 'n' || lower === 'deny') {
-      sessionManager.resolvePermission(msg.channelId, false);
+      await sessionManager.resolvePermission(msg.channelId, false);
       return;
     }
     if (lower === '/remember' || lower === '/always approve') {
       if (sessionManager.isHookPermission(msg.channelId)) {
-        sessionManager.resolvePermission(msg.channelId, true);
+        await sessionManager.resolvePermission(msg.channelId, true);
       } else {
-        sessionManager.resolvePermission(msg.channelId, true, true);
+        await sessionManager.resolvePermission(msg.channelId, true, true);
       }
       return;
     }
     if (lower === '/always deny') {
       if (sessionManager.isHookPermission(msg.channelId)) {
-        sessionManager.resolvePermission(msg.channelId, false);
+        await sessionManager.resolvePermission(msg.channelId, false);
       } else {
-        sessionManager.resolvePermission(msg.channelId, false, true);
+        await sessionManager.resolvePermission(msg.channelId, false, true);
       }
       return;
     }
     // Unrecognized text or slash commands — auto-deny the permission and
     // fall through to process the message normally (mid-turn steering or command).
-    sessionManager.resolvePermission(msg.channelId, false);
+    await sessionManager.resolvePermission(msg.channelId, false);
   }
 
   // Slash commands while busy: handle safe ones immediately, defer the rest
@@ -765,7 +767,7 @@ async function handleMidTurnMessage(
       throw new Error('slash-command-while-busy');
     }
 
-    const channelConfig = getChannelConfig(msg.channelId);
+    const channelConfig = await getChannelConfig(msg.channelId);
     const threadRoot = resolveThreadRoot(msg, threadExtract.threadRequested, channelConfig);
 
     // Commands that MUST run immediately (abort/cancel current work)
@@ -819,8 +821,8 @@ async function handleMidTurnMessage(
 
     if (SAFE_MID_TURN.has(parsed.command)) {
       // Build the same inputs that handleInboundMessage would
-      const sessionInfo = sessionManager.getSessionInfo(msg.channelId);
-      const effPrefs = sessionManager.getEffectivePrefs(msg.channelId);
+      const sessionInfo = await sessionManager.getSessionInfo(msg.channelId);
+      const effPrefs = await sessionManager.getEffectivePrefs(msg.channelId);
       let models: any[] | undefined;
       if (['model', 'models', 'status'].includes(parsed.command)) {
         try { models = await sessionManager.listModels(); } catch { models = undefined; }
@@ -828,7 +830,7 @@ async function handleMidTurnMessage(
       const mcpInfo = undefined;
       const contextUsage = sessionManager.getContextUsage(msg.channelId);
 
-      const cmdResult = handleCommand(
+      const cmdResult = await handleCommand(
         msg.channelId, commandText, sessionInfo ?? undefined,
         { verbose: effPrefs.verbose, permissionMode: effPrefs.permissionMode, reasoningEffort: effPrefs.reasoningEffort },
         { workingDirectory: channelConfig.workingDirectory, bot: channelConfig.bot },
@@ -968,9 +970,9 @@ async function handleInboundMessage(
   }
 
   // Auto-register DM channels for known bots
-  if (!isConfiguredChannel(msg.channelId) && msg.isDM) {
-    const workspacePath = getWorkspacePath(botName);
-    initWorkspace(botName);
+  if (!await isConfiguredChannel(msg.channelId) && msg.isDM) {
+    const workspacePath = await getWorkspacePath(botName);
+    await initWorkspace(botName);
     registerDynamicChannel({
       id: msg.channelId,
       platform: platformName,
@@ -986,23 +988,23 @@ async function handleInboundMessage(
   }
 
   // Only handle configured channels
-  if (!isConfiguredChannel(msg.channelId)) {
+  if (!await isConfiguredChannel(msg.channelId)) {
     log.debug(`Ignoring unconfigured channel ${msg.channelId}`);
     return;
   }
 
   // Only the assigned bot processes messages for this channel (prevents duplicate handling)
-  const assignedBot = getChannelBotName(msg.channelId);
+  const assignedBot = await getChannelBotName(msg.channelId);
   if (assignedBot && assignedBot !== botName) return;
 
-  const resolved = getAdapterForChannel(msg.channelId);
+  const resolved = await getAdapterForChannel(msg.channelId);
   if (!resolved) {
     log.warn(`No adapter for channel ${msg.channelId}`);
     return;
   }
   const { adapter, streaming } = resolved;
 
-  const channelConfig = getChannelConfig(msg.channelId);
+  const channelConfig = await getChannelConfig(msg.channelId);
 
   // Check trigger mode
   const triggerMode = channelConfig.triggerMode;
@@ -1024,8 +1026,8 @@ async function handleInboundMessage(
   if (!text && !msg.attachments?.length) return;
 
   // Check for slash commands
-  const sessionInfo = sessionManager.getSessionInfo(msg.channelId);
-  const effPrefs = sessionManager.getEffectivePrefs(msg.channelId);
+  const sessionInfo = await sessionManager.getSessionInfo(msg.channelId);
+  const effPrefs = await sessionManager.getEffectivePrefs(msg.channelId);
 
   // Fetch models list for commands that need it (model, models, status, reasoning)
   const parsed = parseCommand(text);
@@ -1050,7 +1052,7 @@ async function handleInboundMessage(
   // Get cached context usage for /context and /status
   const contextUsage = sessionManager.getContextUsage(msg.channelId);
 
-  const cmdResult = handleCommand(
+  const cmdResult = await handleCommand(
     msg.channelId, text, sessionInfo ?? undefined,
     { verbose: effPrefs.verbose, permissionMode: effPrefs.permissionMode, reasoningEffort: effPrefs.reasoningEffort },
     { workingDirectory: channelConfig.workingDirectory, bot: channelConfig.bot },
@@ -1130,7 +1132,7 @@ async function handleInboundMessage(
           activeStreams.delete(msg.channelId);
         }
         await finalizeActivityFeed(msg.channelId, adapter);
-        const prevSessionId = sessionManager.getSessionId(msg.channelId);
+        const prevSessionId = await sessionManager.getSessionId(msg.channelId);
         const ackId = await adapter.sendMessage(msg.channelId, '⏳ Reloading session...', { threadRootId: threadRoot });
         const sessionId = await sessionManager.reloadSession(msg.channelId);
         const wasNew = !prevSessionId || sessionId !== prevSessionId;
@@ -1262,7 +1264,7 @@ async function handleInboundMessage(
         break;
       }
       case 'set_reasoning': {
-        const reasoningSessionId = sessionManager.getSessionId(msg.channelId);
+        const reasoningSessionId = await sessionManager.getSessionId(msg.channelId);
         if (!reasoningSessionId) {
           // No active session — pref is saved, will apply on next session creation
           await adapter.sendMessage(msg.channelId, `🧠 Reasoning effort set to **${cmdResult.payload}**. Will apply when a session starts.`, { threadRootId: threadRoot });
@@ -1279,22 +1281,22 @@ async function handleInboundMessage(
         break;
       }
       case 'approve':
-        if (!sessionManager.resolvePermission(msg.channelId, true)) {
+        if (!await sessionManager.resolvePermission(msg.channelId, true)) {
           await adapter.sendMessage(msg.channelId, '⚠️ No pending permission request.', { threadRootId: threadRoot });
         }
         break;
       case 'deny':
-        if (!sessionManager.resolvePermission(msg.channelId, false)) {
+        if (!await sessionManager.resolvePermission(msg.channelId, false)) {
           await adapter.sendMessage(msg.channelId, '⚠️ No pending permission request.', { threadRootId: threadRoot });
         }
         break;
       case 'remember':
-        if (!sessionManager.resolvePermission(msg.channelId, true, true)) {
+        if (!await sessionManager.resolvePermission(msg.channelId, true, true)) {
           await adapter.sendMessage(msg.channelId, '⚠️ No pending permission request.', { threadRootId: threadRoot });
         }
         break;
       case 'remember_deny':
-        if (!sessionManager.resolvePermission(msg.channelId, false, true)) {
+        if (!await sessionManager.resolvePermission(msg.channelId, false, true)) {
           await adapter.sendMessage(msg.channelId, '⚠️ No pending permission request.', { threadRootId: threadRoot });
         }
         break;
@@ -1318,7 +1320,7 @@ async function handleInboundMessage(
           }
 
           // Stored rules (per-channel)
-          const stored = listPermissionRulesForScope(msg.channelId);
+          const stored = await listPermissionRulesForScope(msg.channelId);
           if (stored.length > 0) {
             sections.push('\n**💾 Stored — this channel (skipped in autopilot):**');
             sections.push(...stored.map(r => {
@@ -1340,13 +1342,13 @@ async function handleInboundMessage(
         try {
           const spec = cmdResult.payload as string | undefined;
           if (!spec) {
-            clearPermissionRules(msg.channelId);
+            await clearPermissionRules(msg.channelId);
             await adapter.sendMessage(msg.channelId, '🗑️ All permission rules cleared for this channel.', { threadRootId: threadRoot });
           } else {
             const match = spec.match(/^([^(]+?)(?:\((.+)\))?$/);
             const tool = match?.[1]?.trim() ?? spec;
             const pattern = match?.[2]?.trim() ?? '*';
-            const removed = removePermissionRule(msg.channelId, tool, pattern);
+            const removed = await removePermissionRule(msg.channelId, tool, pattern);
             if (removed) {
               await adapter.sendMessage(msg.channelId, `🗑️ Removed rule: \`${spec}\``, { threadRootId: threadRoot });
             } else {
@@ -1365,7 +1367,7 @@ async function handleInboundMessage(
         const subArg = args?.slice((sub?.length ?? 0)).trim();
 
         if (!sub || sub === 'list') {
-          const tasks = listJobs(msg.channelId);
+          const tasks = await listJobs(msg.channelId);
           if (tasks.length === 0) {
             await adapter.sendMessage(msg.channelId, '📋 No scheduled tasks for this channel.', { threadRootId: threadRoot });
           } else {
@@ -1387,26 +1389,26 @@ async function handleInboundMessage(
           if (!subArg) {
             await adapter.sendMessage(msg.channelId, '⚠️ Usage: `/schedule cancel <id>`', { threadRootId: threadRoot });
           } else {
-            const removed = removeJob(subArg, msg.channelId);
+            const removed = await removeJob(subArg, msg.channelId);
             await adapter.sendMessage(msg.channelId, removed ? `🗑️ Task \`${subArg}\` cancelled.` : `⚠️ Task \`${subArg}\` not found.`, { threadRootId: threadRoot });
           }
         } else if (sub === 'pause') {
           if (!subArg) {
             await adapter.sendMessage(msg.channelId, '⚠️ Usage: `/schedule pause <id>`', { threadRootId: threadRoot });
           } else {
-            const paused = pauseJob(subArg, msg.channelId);
+            const paused = await pauseJob(subArg, msg.channelId);
             await adapter.sendMessage(msg.channelId, paused ? `⏸️ Task \`${subArg}\` paused.` : `⚠️ Task \`${subArg}\` not found.`, { threadRootId: threadRoot });
           }
         } else if (sub === 'resume') {
           if (!subArg) {
             await adapter.sendMessage(msg.channelId, '⚠️ Usage: `/schedule resume <id>`', { threadRootId: threadRoot });
           } else {
-            const resumed = resumeJob(subArg, msg.channelId);
+            const resumed = await resumeJob(subArg, msg.channelId);
             await adapter.sendMessage(msg.channelId, resumed ? `▶️ Task \`${subArg}\` resumed.` : `⚠️ Task \`${subArg}\` not found.`, { threadRootId: threadRoot });
           }
         } else if (sub === 'history' || sub === 'log') {
           const limit = subArg ? parseInt(subArg, 10) || 10 : 10;
-          const entries = getTaskHistory(msg.channelId, limit);
+          const entries = await getTaskHistory(msg.channelId, limit);
           if (entries.length === 0) {
             await adapter.sendMessage(msg.channelId, '📋 No task history for this channel.', { threadRootId: threadRoot });
           } else {
@@ -1425,9 +1427,9 @@ async function handleInboundMessage(
       }
 
       case 'skills': {
-        const skills = sessionManager.getSkillInfo(msg.channelId);
-        const mcpInfo = sessionManager.getMcpServerInfo(msg.channelId);
-        const hooksInfo = sessionManager.getHooksInfo(msg.channelId);
+        const skills = await sessionManager.getSkillInfo(msg.channelId);
+        const mcpInfo = await sessionManager.getMcpServerInfo(msg.channelId);
+        const hooksInfo = await sessionManager.getHooksInfo(msg.channelId);
         const lines: string[] = ['🧰 **Skills & Tools**', ''];
 
         if (skills.length > 0) {
@@ -1493,8 +1495,8 @@ async function handleInboundMessage(
 
       case 'skill_toggle': {
         const { action: toggleAction, targets } = cmdResult.payload as { action: 'enable' | 'disable'; targets: string[] };
-        const skills = sessionManager.getSkillInfo(msg.channelId);
-        const prefs = getChannelPrefs(msg.channelId);
+        const skills = await sessionManager.getSkillInfo(msg.channelId);
+        const prefs = await getChannelPrefs(msg.channelId);
         const currentDisabled = new Set(prefs?.disabledSkills ?? []);
 
         // Handle "all" keyword (only valid as sole target)
@@ -1505,7 +1507,7 @@ async function handleInboundMessage(
           }
           if (toggleAction === 'disable') {
             const allNames = [...new Set(skills.map(s => s.name))];
-            setChannelPrefs(msg.channelId, { disabledSkills: allNames });
+            await setChannelPrefs(msg.channelId, { disabledSkills: allNames });
             // Apply via RPC for each skill
             for (const name of allNames) {
               try { await sessionManager.toggleSkillRpc(msg.channelId, name, 'disable'); } catch { /* best-effort */ }
@@ -1513,7 +1515,7 @@ async function handleInboundMessage(
             await adapter.sendMessage(msg.channelId, `🔴 Disabled all ${allNames.length} skills.`, { threadRootId: threadRoot });
           } else {
             const allNames = [...currentDisabled];
-            setChannelPrefs(msg.channelId, { disabledSkills: [] });
+            await setChannelPrefs(msg.channelId, { disabledSkills: [] });
             for (const name of allNames) {
               try { await sessionManager.toggleSkillRpc(msg.channelId, name, 'enable'); } catch { /* best-effort */ }
             }
@@ -1549,7 +1551,7 @@ async function handleInboundMessage(
         }
 
         if (matched.length > 0) {
-          setChannelPrefs(msg.channelId, { disabledSkills: [...currentDisabled] });
+          await setChannelPrefs(msg.channelId, { disabledSkills: [...currentDisabled] });
           // Apply each toggle via RPC (best-effort — pref is already persisted)
           for (const name of matched) {
             try { await sessionManager.toggleSkillRpc(msg.channelId, name, toggleAction); } catch { /* best-effort */ }
@@ -1573,7 +1575,7 @@ async function handleInboundMessage(
       }
 
       case 'mcp': {
-        const mcpInfo = sessionManager.getMcpServerInfo(msg.channelId);
+        const mcpInfo = await sessionManager.getMcpServerInfo(msg.channelId);
         if (mcpInfo.length === 0) {
           await adapter.sendMessage(msg.channelId, '🔌 No MCP servers configured.', { threadRootId: threadRoot });
           break;
@@ -1722,8 +1724,8 @@ async function handleInboundMessage(
 
           // Save yolo state before changing it
           if (enableYolo) {
-            sessionManager.saveYoloPreviousState(msg.channelId);
-            setChannelPrefs(msg.channelId, { permissionMode: 'autopilot' });
+            await sessionManager.saveYoloPreviousState(msg.channelId);
+            await setChannelPrefs(msg.channelId, { permissionMode: 'autopilot' });
           }
 
           const modeLabel = interactive ? 'interactive' : enableYolo ? 'autopilot + yolo' : 'autopilot';
@@ -1776,7 +1778,7 @@ async function handleInboundMessage(
               { threadRootId: threadRoot });
           } else {
             await sessionManager.setSessionMode(msg.channelId, 'autopilot');
-            const prefs = sessionManager.getEffectivePrefs(msg.channelId);
+            const prefs = await sessionManager.getEffectivePrefs(msg.channelId);
             const yoloWarning = prefs.permissionMode !== 'autopilot'
               ? '\n\n⚠️ Yolo is off — you\'ll still be prompted for tool permissions. Use `/yolo` to auto-approve.'
               : '';
@@ -1805,15 +1807,15 @@ async function handleInboundMessage(
   if (sessionManager.hasPendingPermission(msg.channelId)) {
     const lower = text.toLowerCase();
     if (lower === 'yes' || lower === 'y' || lower === 'approve') {
-      sessionManager.resolvePermission(msg.channelId, true);
+      await sessionManager.resolvePermission(msg.channelId, true);
       return;
     }
     if (lower === 'no' || lower === 'n' || lower === 'deny') {
-      sessionManager.resolvePermission(msg.channelId, false);
+      await sessionManager.resolvePermission(msg.channelId, false);
       return;
     }
     // Unrecognized text — auto-deny and fall through to process as a normal message
-    sessionManager.resolvePermission(msg.channelId, false);
+    await sessionManager.resolvePermission(msg.channelId, false);
   }
 
   // Pending plan exit — auto-dismiss on unrecognized text, process message normally
@@ -1824,7 +1826,7 @@ async function handleInboundMessage(
   // Regular message — forward to Copilot session
   try {
     // Check auth before starting a session (prevents hanging on "Working...")
-    const hasSession = sessionManager.getSessionInfo(msg.channelId);
+    const hasSession = await sessionManager.getSessionInfo(msg.channelId);
     if (!hasSession) {
       const auth = await sessionManager.getAuthStatus();
       if (!auth.isAuthenticated) {
@@ -1914,7 +1916,7 @@ async function handleReaction(
   platformName: string,
   botName: string,
 ): Promise<void> {
-  if (!isConfiguredChannel(reaction.channelId)) return;
+  if (!await isConfiguredChannel(reaction.channelId)) return;
   if (reaction.action !== 'added') return;
 
   // Check user-level access control
@@ -1924,26 +1926,26 @@ async function handleReaction(
     return;
   }
 
-  const resolved = getAdapterForChannel(reaction.channelId);
+  const resolved = await getAdapterForChannel(reaction.channelId);
   if (!resolved) return;
   const { adapter } = resolved;
 
   if (reaction.emoji === 'thumbsup' || reaction.emoji === '+1') {
-    if (sessionManager.resolvePermission(reaction.channelId, true)) {
+    if (await sessionManager.resolvePermission(reaction.channelId, true)) {
       await adapter.sendMessage(reaction.channelId, '✅ Approved via reaction.');
     }
   } else if (reaction.emoji === 'thumbsdown' || reaction.emoji === '-1') {
-    if (sessionManager.resolvePermission(reaction.channelId, false)) {
+    if (await sessionManager.resolvePermission(reaction.channelId, false)) {
       await adapter.sendMessage(reaction.channelId, '❌ Denied via reaction.');
     }
   } else if (reaction.emoji === 'floppy_disk') {
     const isHook = sessionManager.isHookPermission(reaction.channelId);
-    if (sessionManager.resolvePermission(reaction.channelId, true, !isHook)) {
+    if (await sessionManager.resolvePermission(reaction.channelId, true, !isHook)) {
       await adapter.sendMessage(reaction.channelId, isHook ? '✅ Approved via reaction.' : '💾 Approved + remembered via reaction.');
     }
   } else if (reaction.emoji === 'no_entry_sign') {
     const isHook = sessionManager.isHookPermission(reaction.channelId);
-    if (sessionManager.resolvePermission(reaction.channelId, false, !isHook)) {
+    if (await sessionManager.resolvePermission(reaction.channelId, false, !isHook)) {
       await adapter.sendMessage(reaction.channelId, isHook ? '❌ Denied via reaction.' : '🚫 Denied + remembered via reaction.');
     }
   }
@@ -1994,12 +1996,12 @@ async function handleSessionEvent(
     log.debug(`SDK event: ${event.type}`);
   }
 
-  const resolved = getAdapterForChannel(channelId);
+  const resolved = await getAdapterForChannel(channelId);
   if (!resolved) return;
   const { adapter, streaming } = resolved;
 
-  const channelConfig = getChannelConfig(channelId);
-  const prefs = getChannelPrefs(channelId);
+  const channelConfig = await getChannelConfig(channelId);
+  const prefs = await getChannelPrefs(channelId);
   const verbose = prefs?.verbose ?? channelConfig.verbose;
 
   // Handle custom bridge events (permissions, user input)
@@ -2008,7 +2010,7 @@ async function handleSessionEvent(
   if (event.type === 'bridge.permission_request') {
     if (isQuiet(channelId)) {
       log.info(`Auto-denying permission during quiet mode on ${channelId.slice(0, 8)}...`);
-      sessionManager.resolvePermission(channelId, false);
+      await sessionManager.resolvePermission(channelId, false);
       return;
     }
     const streamKey = activeStreams.get(channelId);
@@ -2396,11 +2398,11 @@ async function handleSessionEvent(
           activeStreams.delete(channelId);
         }
         // Revert yolo if it was temporarily enabled for plan implementation
-        if (sessionManager.revertYoloIfNeeded(channelId)) {
+        if (await sessionManager.revertYoloIfNeeded(channelId)) {
           log.info(`Reverted yolo state on idle for ${channelId.slice(0, 8)}...`);
         }
         // Clean up temp files from downloaded attachments
-        cleanupTempFiles(channelId);
+        void cleanupTempFiles(channelId).catch(() => { /* best-effort */ });
       }
       break;
   }
@@ -2460,16 +2462,16 @@ async function finalizeActivityFeed(channelId: string, adapter: ChannelAdapter):
 // --- Startup Restart Notice ---
 
 /** Post a restart notice to admin DM channels (no session creation or LLM interaction). */
-function postRestartNotices(): void {
-  const allSessions = getAllChannelSessions();
+async function postRestartNotices(): Promise<void> {
+  const allSessions = await getAllChannelSessions();
   for (const { channelId } of allSessions) {
-    if (!isConfiguredChannel(channelId)) continue;
-    const channelConfig = getChannelConfig(channelId);
-    const botName = getChannelBotName(channelId);
+    if (!await isConfiguredChannel(channelId)) continue;
+    const channelConfig = await getChannelConfig(channelId);
+    const botName = await getChannelBotName(channelId);
     if (!isBotAdmin(channelConfig.platform, botName)) continue;
     if (!channelConfig.isDM) continue;
 
-    const resolved = getAdapterForChannel(channelId);
+    const resolved = await getAdapterForChannel(channelId);
     if (!resolved) continue;
     resolved.adapter.sendMessage(channelId, '🔄 Bridge restarted.').catch(e =>
       log.warn(`Failed to post restart notice on ${channelId.slice(0, 8)}...:`, e)
@@ -2478,8 +2480,8 @@ function postRestartNotices(): void {
 }
 
 // Start the bridge
-main().catch((err) => {
+main().catch(async (err) => {
   log.error('Fatal error:', err);
-  closeDb();
+  await closeDb();
   process.exit(1);
 });

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -2,7 +2,9 @@ import Database from 'better-sqlite3';
 import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
+import { createLogger } from '../logger.js';
 
+const log = createLogger('store');
 const DB_PATH = path.join(os.homedir(), '.copilot-bridge', 'state.db');
 
 function safeParseStringArray(raw: string): string[] | undefined {
@@ -227,27 +229,47 @@ function getDb(): Database.Database {
 // --- Channel Sessions ---
 
 export async function getChannelSession(channelId: string): Promise<string | null> {
-  const db = getDb();
-  const row = db.prepare('SELECT session_id FROM channel_sessions WHERE channel_id = ?').get(channelId) as { session_id: string } | undefined;
-  return row?.session_id ?? null;
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT session_id FROM channel_sessions WHERE channel_id = ?').get(channelId) as { session_id: string } | undefined;
+    return row?.session_id ?? null;
+  } catch (err) {
+    log.error('getChannelSession failed:', err);
+    throw err;
+  }
 }
 
 export async function setChannelSession(channelId: string, sessionId: string): Promise<void> {
-  const db = getDb();
-  db.prepare(
-    'INSERT OR REPLACE INTO channel_sessions (channel_id, session_id, created_at) VALUES (?, ?, datetime(\'now\'))'
-  ).run(channelId, sessionId);
+  try {
+    const db = getDb();
+    db.prepare(
+      'INSERT OR REPLACE INTO channel_sessions (channel_id, session_id, created_at) VALUES (?, ?, datetime(\'now\'))'
+    ).run(channelId, sessionId);
+  } catch (err) {
+    log.error('setChannelSession failed:', err);
+    throw err;
+  }
 }
 
 export async function clearChannelSession(channelId: string): Promise<void> {
-  const db = getDb();
-  db.prepare('DELETE FROM channel_sessions WHERE channel_id = ?').run(channelId);
+  try {
+    const db = getDb();
+    db.prepare('DELETE FROM channel_sessions WHERE channel_id = ?').run(channelId);
+  } catch (err) {
+    log.error('clearChannelSession failed:', err);
+    throw err;
+  }
 }
 
 export async function getAllChannelSessions(): Promise<Array<{ channelId: string; sessionId: string }>> {
-  const db = getDb();
-  const rows = db.prepare('SELECT channel_id, session_id FROM channel_sessions').all() as any[];
-  return rows.map(r => ({ channelId: r.channel_id, sessionId: r.session_id }));
+  try {
+    const db = getDb();
+    const rows = db.prepare('SELECT channel_id, session_id FROM channel_sessions').all() as any[];
+    return rows.map(r => ({ channelId: r.channel_id, sessionId: r.session_id }));
+  } catch (err) {
+    log.error('getAllChannelSessions failed:', err);
+    throw err;
+  }
 }
 
 // --- Channel Preferences ---
@@ -266,49 +288,59 @@ export interface ChannelPrefs {
 }
 
 export async function getChannelPrefs(channelId: string): Promise<ChannelPrefs | null> {
-  const db = getDb();
-  const row = db.prepare('SELECT * FROM channel_prefs WHERE channel_id = ?').get(channelId) as any;
-  if (!row) return null;
-  return {
-    model: row.model ?? undefined,
-    provider: row.provider ?? null,
-    agent: row.agent,
-    verbose: row.verbose != null ? !!row.verbose : undefined,
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT * FROM channel_prefs WHERE channel_id = ?').get(channelId) as any;
+    if (!row) return null;
+    return {
+      model: row.model ?? undefined,
+      provider: row.provider ?? null,
+      agent: row.agent,
+      verbose: row.verbose != null ? !!row.verbose : undefined,
 
-    threadedReplies: row.threaded_replies != null ? !!row.threaded_replies : undefined,
-    permissionMode: row.permission_mode ?? undefined,
-    reasoningEffort: row.reasoning_effort ?? null,
-    sessionMode: row.session_mode ?? undefined,
-    disabledSkills: row.disabled_skills ? safeParseStringArray(row.disabled_skills) : undefined,
-  };
+      threadedReplies: row.threaded_replies != null ? !!row.threaded_replies : undefined,
+      permissionMode: row.permission_mode ?? undefined,
+      reasoningEffort: row.reasoning_effort ?? null,
+      sessionMode: row.session_mode ?? undefined,
+      disabledSkills: row.disabled_skills ? safeParseStringArray(row.disabled_skills) : undefined,
+    };
+  } catch (err) {
+    log.error('getChannelPrefs failed:', err);
+    throw err;
+  }
 }
 
 export async function setChannelPrefs(channelId: string, prefs: Partial<ChannelPrefs>): Promise<void> {
-  const db = getDb();
+  try {
+    const db = getDb();
 
-  // Ensure a row exists (upsert-safe — avoids TOCTOU race with async callers)
-  db.prepare(
-    `INSERT OR IGNORE INTO channel_prefs (channel_id) VALUES (?)`
-  ).run(channelId);
+    // Ensure a row exists (upsert-safe — avoids TOCTOU race with async callers)
+    db.prepare(
+      `INSERT OR IGNORE INTO channel_prefs (channel_id) VALUES (?)`
+    ).run(channelId);
 
-  const updates: string[] = [];
-  const values: any[] = [];
+    const updates: string[] = [];
+    const values: any[] = [];
 
-  if (prefs.model !== undefined) { updates.push('model = ?'); values.push(prefs.model); }
-  if (prefs.provider !== undefined) { updates.push('provider = ?'); values.push(prefs.provider); }
-  if (prefs.agent !== undefined) { updates.push('agent = ?'); values.push(prefs.agent); }
-  if (prefs.verbose !== undefined) { updates.push('verbose = ?'); values.push(prefs.verbose ? 1 : 0); }
+    if (prefs.model !== undefined) { updates.push('model = ?'); values.push(prefs.model); }
+    if (prefs.provider !== undefined) { updates.push('provider = ?'); values.push(prefs.provider); }
+    if (prefs.agent !== undefined) { updates.push('agent = ?'); values.push(prefs.agent); }
+    if (prefs.verbose !== undefined) { updates.push('verbose = ?'); values.push(prefs.verbose ? 1 : 0); }
 
-  if (prefs.threadedReplies !== undefined) { updates.push('threaded_replies = ?'); values.push(prefs.threadedReplies ? 1 : 0); }
-  if (prefs.permissionMode !== undefined) { updates.push('permission_mode = ?'); values.push(prefs.permissionMode); }
-  if (prefs.reasoningEffort !== undefined) { updates.push('reasoning_effort = ?'); values.push(prefs.reasoningEffort); }
-  if (prefs.sessionMode !== undefined) { updates.push('session_mode = ?'); values.push(prefs.sessionMode); }
-  if (prefs.disabledSkills !== undefined) { updates.push('disabled_skills = ?'); values.push(JSON.stringify(prefs.disabledSkills)); }
+    if (prefs.threadedReplies !== undefined) { updates.push('threaded_replies = ?'); values.push(prefs.threadedReplies ? 1 : 0); }
+    if (prefs.permissionMode !== undefined) { updates.push('permission_mode = ?'); values.push(prefs.permissionMode); }
+    if (prefs.reasoningEffort !== undefined) { updates.push('reasoning_effort = ?'); values.push(prefs.reasoningEffort); }
+    if (prefs.sessionMode !== undefined) { updates.push('session_mode = ?'); values.push(prefs.sessionMode); }
+    if (prefs.disabledSkills !== undefined) { updates.push('disabled_skills = ?'); values.push(JSON.stringify(prefs.disabledSkills)); }
 
-  if (updates.length > 0) {
-    updates.push("updated_at = datetime('now')");
-    values.push(channelId);
-    db.prepare(`UPDATE channel_prefs SET ${updates.join(', ')} WHERE channel_id = ?`).run(...values);
+    if (updates.length > 0) {
+      updates.push("updated_at = datetime('now')");
+      values.push(channelId);
+      db.prepare(`UPDATE channel_prefs SET ${updates.join(', ')} WHERE channel_id = ?`).run(...values);
+    }
+  } catch (err) {
+    log.error('setChannelPrefs failed:', err);
+    throw err;
   }
 }
 
@@ -324,60 +356,85 @@ export interface StoredPermissionRule {
 }
 
 export async function getPermissionRules(scope: string, tool: string): Promise<StoredPermissionRule[]> {
-  const db = getDb();
-  const rows = db.prepare(
-    'SELECT * FROM permission_rules WHERE (scope = ? OR scope = \'global\') AND tool = ? ORDER BY scope DESC, id DESC'
-  ).all(scope, tool) as any[];
-  return rows.map(r => ({
-    id: r.id,
-    scope: r.scope,
-    tool: r.tool,
-    commandPattern: r.command_pattern,
-    action: r.action,
-    createdAt: r.created_at,
-  }));
+  try {
+    const db = getDb();
+    const rows = db.prepare(
+      'SELECT * FROM permission_rules WHERE (scope = ? OR scope = \'global\') AND tool = ? ORDER BY scope DESC, id DESC'
+    ).all(scope, tool) as any[];
+    return rows.map(r => ({
+      id: r.id,
+      scope: r.scope,
+      tool: r.tool,
+      commandPattern: r.command_pattern,
+      action: r.action,
+      createdAt: r.created_at,
+    }));
+  } catch (err) {
+    log.error('getPermissionRules failed:', err);
+    throw err;
+  }
 }
 
 export async function addPermissionRule(scope: string, tool: string, commandPattern: string, action: 'allow' | 'deny'): Promise<void> {
-  const db = getDb();
-  // Remove existing rule for same scope+tool+pattern before inserting
-  db.prepare(
-    'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
-  ).run(scope, tool, commandPattern);
+  try {
+    const db = getDb();
+    // Remove existing rule for same scope+tool+pattern before inserting
+    db.prepare(
+      'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
+    ).run(scope, tool, commandPattern);
 
-  db.prepare(
-    'INSERT INTO permission_rules (scope, tool, command_pattern, action) VALUES (?, ?, ?, ?)'
-  ).run(scope, tool, commandPattern, action);
+    db.prepare(
+      'INSERT INTO permission_rules (scope, tool, command_pattern, action) VALUES (?, ?, ?, ?)'
+    ).run(scope, tool, commandPattern, action);
+  } catch (err) {
+    log.error('addPermissionRule failed:', err);
+    throw err;
+  }
 }
 
 export async function clearPermissionRules(scope: string): Promise<void> {
-  const db = getDb();
-  db.prepare('DELETE FROM permission_rules WHERE scope = ?').run(scope);
+  try {
+    const db = getDb();
+    db.prepare('DELETE FROM permission_rules WHERE scope = ?').run(scope);
+  } catch (err) {
+    log.error('clearPermissionRules failed:', err);
+    throw err;
+  }
 }
 
 /** Remove a specific permission rule by scope + tool + command_pattern. */
 export async function removePermissionRule(scope: string, tool: string, commandPattern: string): Promise<boolean> {
-  const db = getDb();
-  const result = db.prepare(
-    'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
-  ).run(scope, tool, commandPattern);
-  return result.changes > 0;
+  try {
+    const db = getDb();
+    const result = db.prepare(
+      'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
+    ).run(scope, tool, commandPattern);
+    return result.changes > 0;
+  } catch (err) {
+    log.error('removePermissionRule failed:', err);
+    throw err;
+  }
 }
 
 /** List all permission rules for a scope. */
 export async function listPermissionRulesForScope(scope: string): Promise<StoredPermissionRule[]> {
-  const db = getDb();
-  const rows = db.prepare(
-    'SELECT * FROM permission_rules WHERE scope = ? ORDER BY tool, command_pattern'
-  ).all(scope) as any[];
-  return rows.map(r => ({
-    id: r.id,
-    scope: r.scope,
-    tool: r.tool,
-    commandPattern: r.command_pattern,
-    action: r.action,
-    createdAt: r.created_at,
-  }));
+  try {
+    const db = getDb();
+    const rows = db.prepare(
+      'SELECT * FROM permission_rules WHERE scope = ? ORDER BY tool, command_pattern'
+    ).all(scope) as any[];
+    return rows.map(r => ({
+      id: r.id,
+      scope: r.scope,
+      tool: r.tool,
+      commandPattern: r.command_pattern,
+      action: r.action,
+      createdAt: r.created_at,
+    }));
+  } catch (err) {
+    log.error('listPermissionRulesForScope failed:', err);
+    throw err;
+  }
 }
 
 /**
@@ -416,58 +473,88 @@ function safeParseAllowPaths(raw: string): string[] {
 }
 
 export async function getWorkspaceOverride(botName: string): Promise<WorkspaceOverride | null> {
-  const db = getDb();
-  const row = db.prepare('SELECT * FROM workspace_overrides WHERE bot_name = ?').get(botName) as any;
-  if (!row) return null;
-  return {
-    botName: row.bot_name,
-    workingDirectory: row.working_directory,
-    allowPaths: safeParseAllowPaths(row.allow_paths),
-    createdAt: row.created_at,
-  };
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT * FROM workspace_overrides WHERE bot_name = ?').get(botName) as any;
+    if (!row) return null;
+    return {
+      botName: row.bot_name,
+      workingDirectory: row.working_directory,
+      allowPaths: safeParseAllowPaths(row.allow_paths),
+      createdAt: row.created_at,
+    };
+  } catch (err) {
+    log.error('getWorkspaceOverride failed:', err);
+    throw err;
+  }
 }
 
 export async function setWorkspaceOverride(botName: string, workingDirectory: string, allowPaths?: string[]): Promise<void> {
-  const db = getDb();
-  db.prepare(
-    `INSERT INTO workspace_overrides (bot_name, working_directory, allow_paths, created_at)
-     VALUES (?, ?, ?, datetime('now'))
-     ON CONFLICT(bot_name) DO UPDATE SET
-       working_directory = excluded.working_directory,
-       allow_paths = excluded.allow_paths`
-  ).run(botName, workingDirectory, JSON.stringify(allowPaths ?? []));
+  try {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO workspace_overrides (bot_name, working_directory, allow_paths, created_at)
+       VALUES (?, ?, ?, datetime('now'))
+       ON CONFLICT(bot_name) DO UPDATE SET
+         working_directory = excluded.working_directory,
+         allow_paths = excluded.allow_paths`
+    ).run(botName, workingDirectory, JSON.stringify(allowPaths ?? []));
+  } catch (err) {
+    log.error('setWorkspaceOverride failed:', err);
+    throw err;
+  }
 }
 
 export async function removeWorkspaceOverride(botName: string): Promise<void> {
-  const db = getDb();
-  db.prepare('DELETE FROM workspace_overrides WHERE bot_name = ?').run(botName);
+  try {
+    const db = getDb();
+    db.prepare('DELETE FROM workspace_overrides WHERE bot_name = ?').run(botName);
+  } catch (err) {
+    log.error('removeWorkspaceOverride failed:', err);
+    throw err;
+  }
 }
 
 export async function listWorkspaceOverrides(): Promise<WorkspaceOverride[]> {
-  const db = getDb();
-  const rows = db.prepare('SELECT * FROM workspace_overrides').all() as any[];
-  return rows.map(row => ({
-    botName: row.bot_name,
-    workingDirectory: row.working_directory,
-    allowPaths: safeParseAllowPaths(row.allow_paths),
-    createdAt: row.created_at,
-  }));
+  try {
+    const db = getDb();
+    const rows = db.prepare('SELECT * FROM workspace_overrides').all() as any[];
+    return rows.map(row => ({
+      botName: row.bot_name,
+      workingDirectory: row.working_directory,
+      allowPaths: safeParseAllowPaths(row.allow_paths),
+      createdAt: row.created_at,
+    }));
+  } catch (err) {
+    log.error('listWorkspaceOverrides failed:', err);
+    throw err;
+  }
 }
 
 // --- Global Settings ---
 
 export async function getGlobalSetting(key: string): Promise<string | null> {
-  const db = getDb();
-  const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
-  return row?.value ?? null;
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
+    return row?.value ?? null;
+  } catch (err) {
+    log.error('getGlobalSetting failed:', err);
+    throw err;
+  }
 }
 
 export async function setGlobalSetting(key: string, value: string): Promise<void> {
-  const db = getDb();
-  db.prepare(
-    `INSERT INTO settings (key, value) VALUES (?, ?)
-     ON CONFLICT(key) DO UPDATE SET value = excluded.value`
-  ).run(key, value);
+  try {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO settings (key, value) VALUES (?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+    ).run(key, value);
+  } catch (err) {
+    log.error('setGlobalSetting failed:', err);
+    throw err;
+  }
 }
 
 // --- Dynamic Channels ---
@@ -489,47 +576,67 @@ export interface DynamicChannel {
 }
 
 export async function addDynamicChannel(channel: Omit<DynamicChannel, 'createdAt' | 'updatedAt'>): Promise<void> {
-  const db = getDb();
-  db.prepare(
-    `INSERT INTO dynamic_channels (channel_id, platform, name, bot, working_directory, agent, model, trigger_mode, threaded_replies, verbose, is_dm)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(channel_id) DO UPDATE SET
-       platform = excluded.platform, name = excluded.name, bot = excluded.bot,
-       working_directory = excluded.working_directory, agent = excluded.agent,
-       model = excluded.model, trigger_mode = excluded.trigger_mode,
-       threaded_replies = excluded.threaded_replies, verbose = excluded.verbose,
-       is_dm = excluded.is_dm, updated_at = datetime('now')`
-  ).run(
-    channel.channelId,
-    channel.platform,
-    channel.name ?? '',
-    channel.bot ?? null,
-    channel.workingDirectory,
-    channel.agent ?? null,
-    channel.model ?? null,
-    channel.triggerMode ?? null,
-    channel.threadedReplies != null ? (channel.threadedReplies ? 1 : 0) : null,
-    channel.verbose != null ? (channel.verbose ? 1 : 0) : null,
-    channel.isDM ? 1 : 0,
-  );
+  try {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO dynamic_channels (channel_id, platform, name, bot, working_directory, agent, model, trigger_mode, threaded_replies, verbose, is_dm)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(channel_id) DO UPDATE SET
+         platform = excluded.platform, name = excluded.name, bot = excluded.bot,
+         working_directory = excluded.working_directory, agent = excluded.agent,
+         model = excluded.model, trigger_mode = excluded.trigger_mode,
+         threaded_replies = excluded.threaded_replies, verbose = excluded.verbose,
+         is_dm = excluded.is_dm, updated_at = datetime('now')`
+    ).run(
+      channel.channelId,
+      channel.platform,
+      channel.name ?? '',
+      channel.bot ?? null,
+      channel.workingDirectory,
+      channel.agent ?? null,
+      channel.model ?? null,
+      channel.triggerMode ?? null,
+      channel.threadedReplies != null ? (channel.threadedReplies ? 1 : 0) : null,
+      channel.verbose != null ? (channel.verbose ? 1 : 0) : null,
+      channel.isDM ? 1 : 0,
+    );
+  } catch (err) {
+    log.error('addDynamicChannel failed:', err);
+    throw err;
+  }
 }
 
 export async function removeDynamicChannel(channelId: string): Promise<void> {
-  const db = getDb();
-  db.prepare('DELETE FROM dynamic_channels WHERE channel_id = ?').run(channelId);
+  try {
+    const db = getDb();
+    db.prepare('DELETE FROM dynamic_channels WHERE channel_id = ?').run(channelId);
+  } catch (err) {
+    log.error('removeDynamicChannel failed:', err);
+    throw err;
+  }
 }
 
 export async function getDynamicChannel(channelId: string): Promise<DynamicChannel | null> {
-  const db = getDb();
-  const row = db.prepare('SELECT * FROM dynamic_channels WHERE channel_id = ?').get(channelId) as any;
-  if (!row) return null;
-  return mapDynamicChannelRow(row);
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT * FROM dynamic_channels WHERE channel_id = ?').get(channelId) as any;
+    if (!row) return null;
+    return mapDynamicChannelRow(row);
+  } catch (err) {
+    log.error('getDynamicChannel failed:', err);
+    throw err;
+  }
 }
 
 export async function getDynamicChannels(): Promise<DynamicChannel[]> {
-  const db = getDb();
-  const rows = db.prepare('SELECT * FROM dynamic_channels ORDER BY created_at').all() as any[];
-  return rows.map(mapDynamicChannelRow);
+  try {
+    const db = getDb();
+    const rows = db.prepare('SELECT * FROM dynamic_channels ORDER BY created_at').all() as any[];
+    return rows.map(mapDynamicChannelRow);
+  } catch (err) {
+    log.error('getDynamicChannels failed:', err);
+    throw err;
+  }
 }
 
 function mapDynamicChannelRow(row: any): DynamicChannel {
@@ -566,43 +673,53 @@ export interface AgentCallRecord {
 }
 
 export async function recordAgentCall(record: AgentCallRecord): Promise<void> {
-  const db = getDb();
-  db.prepare(
-    `INSERT INTO agent_calls (caller_bot, target_bot, target_agent, message_summary, response_summary, duration_ms, success, error, chain_id, depth)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  ).run(
-    record.callerBot,
-    record.targetBot,
-    record.targetAgent ?? null,
-    record.messageSummary ?? null,
-    record.responseSummary ?? null,
-    record.durationMs ?? null,
-    record.success ? 1 : 0,
-    record.error ?? null,
-    record.chainId ?? null,
-    record.depth ?? 0,
-  );
+  try {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO agent_calls (caller_bot, target_bot, target_agent, message_summary, response_summary, duration_ms, success, error, chain_id, depth)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      record.callerBot,
+      record.targetBot,
+      record.targetAgent ?? null,
+      record.messageSummary ?? null,
+      record.responseSummary ?? null,
+      record.durationMs ?? null,
+      record.success ? 1 : 0,
+      record.error ?? null,
+      record.chainId ?? null,
+      record.depth ?? 0,
+    );
+  } catch (err) {
+    log.error('recordAgentCall failed:', err);
+    throw err;
+  }
 }
 
 export async function getRecentAgentCalls(limit: number = 20): Promise<Array<AgentCallRecord & { id: number; createdAt: string }>> {
-  const db = getDb();
-  const rows = db.prepare(
-    'SELECT * FROM agent_calls ORDER BY created_at DESC LIMIT ?'
-  ).all(limit) as any[];
-  return rows.map(r => ({
-    id: r.id,
-    callerBot: r.caller_bot,
-    targetBot: r.target_bot,
-    targetAgent: r.target_agent ?? undefined,
-    messageSummary: r.message_summary ?? undefined,
-    responseSummary: r.response_summary ?? undefined,
-    durationMs: r.duration_ms ?? undefined,
-    success: !!r.success,
-    error: r.error ?? undefined,
-    chainId: r.chain_id ?? undefined,
-    depth: r.depth ?? 0,
-    createdAt: r.created_at,
-  }));
+  try {
+    const db = getDb();
+    const rows = db.prepare(
+      'SELECT * FROM agent_calls ORDER BY created_at DESC LIMIT ?'
+    ).all(limit) as any[];
+    return rows.map(r => ({
+      id: r.id,
+      callerBot: r.caller_bot,
+      targetBot: r.target_bot,
+      targetAgent: r.target_agent ?? undefined,
+      messageSummary: r.message_summary ?? undefined,
+      responseSummary: r.response_summary ?? undefined,
+      durationMs: r.duration_ms ?? undefined,
+      success: !!r.success,
+      error: r.error ?? undefined,
+      chainId: r.chain_id ?? undefined,
+      depth: r.depth ?? 0,
+      createdAt: r.created_at,
+    }));
+  } catch (err) {
+    log.error('getRecentAgentCalls failed:', err);
+    throw err;
+  }
 }
 
 // --- Scheduled Tasks ---
@@ -624,52 +741,87 @@ export interface ScheduledTask {
 }
 
 export async function insertScheduledTask(task: Omit<ScheduledTask, 'createdAt' | 'lastRun' | 'nextRun'> & { nextRun?: string }): Promise<void> {
-  const db = getDb();
-  db.prepare(`
-    INSERT INTO scheduled_tasks (id, channel_id, bot_name, prompt, cron_expr, run_at, timezone, created_by, description, enabled, next_run)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(
-    task.id, task.channelId, task.botName, task.prompt,
-    task.cronExpr ?? null, task.runAt ?? null, task.timezone,
-    task.createdBy ?? null, task.description ?? null,
-    task.enabled ? 1 : 0, task.nextRun ?? null,
-  );
+  try {
+    const db = getDb();
+    db.prepare(`
+      INSERT INTO scheduled_tasks (id, channel_id, bot_name, prompt, cron_expr, run_at, timezone, created_by, description, enabled, next_run)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      task.id, task.channelId, task.botName, task.prompt,
+      task.cronExpr ?? null, task.runAt ?? null, task.timezone,
+      task.createdBy ?? null, task.description ?? null,
+      task.enabled ? 1 : 0, task.nextRun ?? null,
+    );
+  } catch (err) {
+    log.error('insertScheduledTask failed:', err);
+    throw err;
+  }
 }
 
 export async function getScheduledTask(id: string): Promise<ScheduledTask | null> {
-  const db = getDb();
-  const row = db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as any;
-  return row ? mapTaskRow(row) : null;
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as any;
+    return row ? mapTaskRow(row) : null;
+  } catch (err) {
+    log.error('getScheduledTask failed:', err);
+    throw err;
+  }
 }
 
 export async function getScheduledTasksForChannel(channelId: string): Promise<ScheduledTask[]> {
-  const db = getDb();
-  // Show enabled tasks + paused recurring tasks (exclude disabled one-offs — they're finished)
-  const rows = db.prepare(
-    'SELECT * FROM scheduled_tasks WHERE channel_id = ? AND (enabled = 1 OR cron_expr IS NOT NULL) ORDER BY created_at DESC'
-  ).all(channelId) as any[];
-  return rows.map(mapTaskRow);
+  try {
+    const db = getDb();
+    // Show enabled tasks + paused recurring tasks (exclude disabled one-offs — they're finished)
+    const rows = db.prepare(
+      'SELECT * FROM scheduled_tasks WHERE channel_id = ? AND (enabled = 1 OR cron_expr IS NOT NULL) ORDER BY created_at DESC'
+    ).all(channelId) as any[];
+    return rows.map(mapTaskRow);
+  } catch (err) {
+    log.error('getScheduledTasksForChannel failed:', err);
+    throw err;
+  }
 }
 
 export async function getEnabledScheduledTasks(): Promise<ScheduledTask[]> {
-  const db = getDb();
-  const rows = db.prepare('SELECT * FROM scheduled_tasks WHERE enabled = 1').all() as any[];
-  return rows.map(mapTaskRow);
+  try {
+    const db = getDb();
+    const rows = db.prepare('SELECT * FROM scheduled_tasks WHERE enabled = 1').all() as any[];
+    return rows.map(mapTaskRow);
+  } catch (err) {
+    log.error('getEnabledScheduledTasks failed:', err);
+    throw err;
+  }
 }
 
 export async function updateScheduledTaskEnabled(id: string, enabled: boolean): Promise<void> {
-  const db = getDb();
-  db.prepare('UPDATE scheduled_tasks SET enabled = ? WHERE id = ?').run(enabled ? 1 : 0, id);
+  try {
+    const db = getDb();
+    db.prepare('UPDATE scheduled_tasks SET enabled = ? WHERE id = ?').run(enabled ? 1 : 0, id);
+  } catch (err) {
+    log.error('updateScheduledTaskEnabled failed:', err);
+    throw err;
+  }
 }
 
 export async function updateScheduledTaskLastRun(id: string, lastRun: string, nextRun?: string): Promise<void> {
-  const db = getDb();
-  db.prepare('UPDATE scheduled_tasks SET last_run = ?, next_run = ? WHERE id = ?').run(lastRun, nextRun ?? null, id);
+  try {
+    const db = getDb();
+    db.prepare('UPDATE scheduled_tasks SET last_run = ?, next_run = ? WHERE id = ?').run(lastRun, nextRun ?? null, id);
+  } catch (err) {
+    log.error('updateScheduledTaskLastRun failed:', err);
+    throw err;
+  }
 }
 
 export async function deleteScheduledTask(id: string): Promise<void> {
-  const db = getDb();
-  db.prepare('DELETE FROM scheduled_tasks WHERE id = ?').run(id);
+  try {
+    const db = getDb();
+    db.prepare('DELETE FROM scheduled_tasks WHERE id = ?').run(id);
+  } catch (err) {
+    log.error('deleteScheduledTask failed:', err);
+    throw err;
+  }
 }
 
 function mapTaskRow(r: any): ScheduledTask {
@@ -705,29 +857,39 @@ export interface TaskHistoryEntry {
 }
 
 export async function insertTaskHistory(entry: Omit<TaskHistoryEntry, 'id' | 'firedAt'>): Promise<void> {
-  const db = getDb();
-  db.prepare(`
-    INSERT INTO scheduled_task_history (task_id, channel_id, prompt, description, timezone, status, fired_at, error)
-    VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)
-  `).run(entry.taskId, entry.channelId, entry.prompt, entry.description ?? null, entry.timezone, entry.status, entry.error ?? null);
+  try {
+    const db = getDb();
+    db.prepare(`
+      INSERT INTO scheduled_task_history (task_id, channel_id, prompt, description, timezone, status, fired_at, error)
+      VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)
+    `).run(entry.taskId, entry.channelId, entry.prompt, entry.description ?? null, entry.timezone, entry.status, entry.error ?? null);
+  } catch (err) {
+    log.error('insertTaskHistory failed:', err);
+    throw err;
+  }
 }
 
 export async function getTaskHistory(channelId: string, limit = 20): Promise<TaskHistoryEntry[]> {
-  const db = getDb();
-  const rows = db.prepare(
-    'SELECT * FROM scheduled_task_history WHERE channel_id = ? ORDER BY fired_at DESC LIMIT ?'
-  ).all(channelId, limit) as any[];
-  return rows.map(r => ({
-    id: r.id,
-    taskId: r.task_id,
-    channelId: r.channel_id,
-    prompt: r.prompt,
-    description: r.description ?? undefined,
-    timezone: r.timezone ?? 'UTC',
-    status: r.status,
-    firedAt: r.fired_at,
-    error: r.error ?? undefined,
-  }));
+  try {
+    const db = getDb();
+    const rows = db.prepare(
+      'SELECT * FROM scheduled_task_history WHERE channel_id = ? ORDER BY fired_at DESC LIMIT ?'
+    ).all(channelId, limit) as any[];
+    return rows.map(r => ({
+      id: r.id,
+      taskId: r.task_id,
+      channelId: r.channel_id,
+      prompt: r.prompt,
+      description: r.description ?? undefined,
+      timezone: r.timezone ?? 'UTC',
+      status: r.status,
+      firedAt: r.fired_at,
+      error: r.error ?? undefined,
+    }));
+  } catch (err) {
+    log.error('getTaskHistory failed:', err);
+    throw err;
+  }
 }
 
 // --- Cleanup ---

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1173,6 +1173,11 @@ export async function getTaskHistory(channelId: string, limit = 20): Promise<Tas
 // --- Cleanup ---
 
 export async function closeDb(): Promise<void> {
-  _db?.close();
-  _db = null;
+  try {
+    _db?.close();
+  } catch (err) {
+    log.warn('Failed to close database cleanly:', err);
+  } finally {
+    _db = null;
+  }
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -226,25 +226,25 @@ function getDb(): Database.Database {
 
 // --- Channel Sessions ---
 
-export function getChannelSession(channelId: string): string | null {
+export async function getChannelSession(channelId: string): Promise<string | null> {
   const db = getDb();
   const row = db.prepare('SELECT session_id FROM channel_sessions WHERE channel_id = ?').get(channelId) as { session_id: string } | undefined;
   return row?.session_id ?? null;
 }
 
-export function setChannelSession(channelId: string, sessionId: string): void {
+export async function setChannelSession(channelId: string, sessionId: string): Promise<void> {
   const db = getDb();
   db.prepare(
     'INSERT OR REPLACE INTO channel_sessions (channel_id, session_id, created_at) VALUES (?, ?, datetime(\'now\'))'
   ).run(channelId, sessionId);
 }
 
-export function clearChannelSession(channelId: string): void {
+export async function clearChannelSession(channelId: string): Promise<void> {
   const db = getDb();
   db.prepare('DELETE FROM channel_sessions WHERE channel_id = ?').run(channelId);
 }
 
-export function getAllChannelSessions(): Array<{ channelId: string; sessionId: string }> {
+export async function getAllChannelSessions(): Promise<Array<{ channelId: string; sessionId: string }>> {
   const db = getDb();
   const rows = db.prepare('SELECT channel_id, session_id FROM channel_sessions').all() as any[];
   return rows.map(r => ({ channelId: r.channel_id, sessionId: r.session_id }));
@@ -265,7 +265,7 @@ export interface ChannelPrefs {
   disabledSkills?: string[];
 }
 
-export function getChannelPrefs(channelId: string): ChannelPrefs | null {
+export async function getChannelPrefs(channelId: string): Promise<ChannelPrefs | null> {
   const db = getDb();
   const row = db.prepare('SELECT * FROM channel_prefs WHERE channel_id = ?').get(channelId) as any;
   if (!row) return null;
@@ -283,46 +283,32 @@ export function getChannelPrefs(channelId: string): ChannelPrefs | null {
   };
 }
 
-export function setChannelPrefs(channelId: string, prefs: Partial<ChannelPrefs>): void {
+export async function setChannelPrefs(channelId: string, prefs: Partial<ChannelPrefs>): Promise<void> {
   const db = getDb();
-  const existing = getChannelPrefs(channelId);
 
-  if (existing) {
-    const updates: string[] = [];
-    const values: any[] = [];
+  // Ensure a row exists (upsert-safe — avoids TOCTOU race with async callers)
+  db.prepare(
+    `INSERT OR IGNORE INTO channel_prefs (channel_id) VALUES (?)`
+  ).run(channelId);
 
-    if (prefs.model !== undefined) { updates.push('model = ?'); values.push(prefs.model); }
-    if (prefs.provider !== undefined) { updates.push('provider = ?'); values.push(prefs.provider); }
-    if (prefs.agent !== undefined) { updates.push('agent = ?'); values.push(prefs.agent); }
-    if (prefs.verbose !== undefined) { updates.push('verbose = ?'); values.push(prefs.verbose ? 1 : 0); }
+  const updates: string[] = [];
+  const values: any[] = [];
 
-    if (prefs.threadedReplies !== undefined) { updates.push('threaded_replies = ?'); values.push(prefs.threadedReplies ? 1 : 0); }
-    if (prefs.permissionMode !== undefined) { updates.push('permission_mode = ?'); values.push(prefs.permissionMode); }
-    if (prefs.reasoningEffort !== undefined) { updates.push('reasoning_effort = ?'); values.push(prefs.reasoningEffort); }
-    if (prefs.sessionMode !== undefined) { updates.push('session_mode = ?'); values.push(prefs.sessionMode); }
-    if (prefs.disabledSkills !== undefined) { updates.push('disabled_skills = ?'); values.push(JSON.stringify(prefs.disabledSkills)); }
+  if (prefs.model !== undefined) { updates.push('model = ?'); values.push(prefs.model); }
+  if (prefs.provider !== undefined) { updates.push('provider = ?'); values.push(prefs.provider); }
+  if (prefs.agent !== undefined) { updates.push('agent = ?'); values.push(prefs.agent); }
+  if (prefs.verbose !== undefined) { updates.push('verbose = ?'); values.push(prefs.verbose ? 1 : 0); }
 
-    if (updates.length > 0) {
-      updates.push("updated_at = datetime('now')");
-      values.push(channelId);
-      db.prepare(`UPDATE channel_prefs SET ${updates.join(', ')} WHERE channel_id = ?`).run(...values);
-    }
-  } else {
-    db.prepare(
-      `INSERT INTO channel_prefs (channel_id, model, provider, agent, verbose, threaded_replies, permission_mode, reasoning_effort, session_mode, disabled_skills)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      channelId,
-      prefs.model ?? null,
-      prefs.provider ?? null,
-      prefs.agent ?? null,
-      prefs.verbose != null ? (prefs.verbose ? 1 : 0) : null,
-      prefs.threadedReplies != null ? (prefs.threadedReplies ? 1 : 0) : null,
-      prefs.permissionMode ?? null,
-      prefs.reasoningEffort ?? null,
-      prefs.sessionMode ?? null,
-      prefs.disabledSkills?.length ? JSON.stringify(prefs.disabledSkills) : null,
-    );
+  if (prefs.threadedReplies !== undefined) { updates.push('threaded_replies = ?'); values.push(prefs.threadedReplies ? 1 : 0); }
+  if (prefs.permissionMode !== undefined) { updates.push('permission_mode = ?'); values.push(prefs.permissionMode); }
+  if (prefs.reasoningEffort !== undefined) { updates.push('reasoning_effort = ?'); values.push(prefs.reasoningEffort); }
+  if (prefs.sessionMode !== undefined) { updates.push('session_mode = ?'); values.push(prefs.sessionMode); }
+  if (prefs.disabledSkills !== undefined) { updates.push('disabled_skills = ?'); values.push(JSON.stringify(prefs.disabledSkills)); }
+
+  if (updates.length > 0) {
+    updates.push("updated_at = datetime('now')");
+    values.push(channelId);
+    db.prepare(`UPDATE channel_prefs SET ${updates.join(', ')} WHERE channel_id = ?`).run(...values);
   }
 }
 
@@ -337,7 +323,7 @@ export interface StoredPermissionRule {
   createdAt: string;
 }
 
-export function getPermissionRules(scope: string, tool: string): StoredPermissionRule[] {
+export async function getPermissionRules(scope: string, tool: string): Promise<StoredPermissionRule[]> {
   const db = getDb();
   const rows = db.prepare(
     'SELECT * FROM permission_rules WHERE (scope = ? OR scope = \'global\') AND tool = ? ORDER BY scope DESC, id DESC'
@@ -352,7 +338,7 @@ export function getPermissionRules(scope: string, tool: string): StoredPermissio
   }));
 }
 
-export function addPermissionRule(scope: string, tool: string, commandPattern: string, action: 'allow' | 'deny'): void {
+export async function addPermissionRule(scope: string, tool: string, commandPattern: string, action: 'allow' | 'deny'): Promise<void> {
   const db = getDb();
   // Remove existing rule for same scope+tool+pattern before inserting
   db.prepare(
@@ -364,13 +350,13 @@ export function addPermissionRule(scope: string, tool: string, commandPattern: s
   ).run(scope, tool, commandPattern, action);
 }
 
-export function clearPermissionRules(scope: string): void {
+export async function clearPermissionRules(scope: string): Promise<void> {
   const db = getDb();
   db.prepare('DELETE FROM permission_rules WHERE scope = ?').run(scope);
 }
 
 /** Remove a specific permission rule by scope + tool + command_pattern. */
-export function removePermissionRule(scope: string, tool: string, commandPattern: string): boolean {
+export async function removePermissionRule(scope: string, tool: string, commandPattern: string): Promise<boolean> {
   const db = getDb();
   const result = db.prepare(
     'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
@@ -379,7 +365,7 @@ export function removePermissionRule(scope: string, tool: string, commandPattern
 }
 
 /** List all permission rules for a scope. */
-export function listPermissionRulesForScope(scope: string): StoredPermissionRule[] {
+export async function listPermissionRulesForScope(scope: string): Promise<StoredPermissionRule[]> {
   const db = getDb();
   const rows = db.prepare(
     'SELECT * FROM permission_rules WHERE scope = ? ORDER BY tool, command_pattern'
@@ -398,8 +384,8 @@ export function listPermissionRulesForScope(scope: string): StoredPermissionRule
  * Check if a tool+command is allowed by existing rules.
  * Returns 'allow', 'deny', or null (no matching rule — need to ask).
  */
-export function checkPermission(scope: string, tool: string, command: string): 'allow' | 'deny' | null {
-  const rules = getPermissionRules(scope, tool);
+export async function checkPermission(scope: string, tool: string, command: string): Promise<'allow' | 'deny' | null> {
+  const rules = await getPermissionRules(scope, tool);
 
   for (const rule of rules) {
     // Exact match or wildcard
@@ -429,7 +415,7 @@ function safeParseAllowPaths(raw: string): string[] {
   }
 }
 
-export function getWorkspaceOverride(botName: string): WorkspaceOverride | null {
+export async function getWorkspaceOverride(botName: string): Promise<WorkspaceOverride | null> {
   const db = getDb();
   const row = db.prepare('SELECT * FROM workspace_overrides WHERE bot_name = ?').get(botName) as any;
   if (!row) return null;
@@ -441,7 +427,7 @@ export function getWorkspaceOverride(botName: string): WorkspaceOverride | null 
   };
 }
 
-export function setWorkspaceOverride(botName: string, workingDirectory: string, allowPaths?: string[]): void {
+export async function setWorkspaceOverride(botName: string, workingDirectory: string, allowPaths?: string[]): Promise<void> {
   const db = getDb();
   db.prepare(
     `INSERT INTO workspace_overrides (bot_name, working_directory, allow_paths, created_at)
@@ -452,12 +438,12 @@ export function setWorkspaceOverride(botName: string, workingDirectory: string, 
   ).run(botName, workingDirectory, JSON.stringify(allowPaths ?? []));
 }
 
-export function removeWorkspaceOverride(botName: string): void {
+export async function removeWorkspaceOverride(botName: string): Promise<void> {
   const db = getDb();
   db.prepare('DELETE FROM workspace_overrides WHERE bot_name = ?').run(botName);
 }
 
-export function listWorkspaceOverrides(): WorkspaceOverride[] {
+export async function listWorkspaceOverrides(): Promise<WorkspaceOverride[]> {
   const db = getDb();
   const rows = db.prepare('SELECT * FROM workspace_overrides').all() as any[];
   return rows.map(row => ({
@@ -470,13 +456,13 @@ export function listWorkspaceOverrides(): WorkspaceOverride[] {
 
 // --- Global Settings ---
 
-export function getGlobalSetting(key: string): string | null {
+export async function getGlobalSetting(key: string): Promise<string | null> {
   const db = getDb();
   const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
   return row?.value ?? null;
 }
 
-export function setGlobalSetting(key: string, value: string): void {
+export async function setGlobalSetting(key: string, value: string): Promise<void> {
   const db = getDb();
   db.prepare(
     `INSERT INTO settings (key, value) VALUES (?, ?)
@@ -502,7 +488,7 @@ export interface DynamicChannel {
   updatedAt: string;
 }
 
-export function addDynamicChannel(channel: Omit<DynamicChannel, 'createdAt' | 'updatedAt'>): void {
+export async function addDynamicChannel(channel: Omit<DynamicChannel, 'createdAt' | 'updatedAt'>): Promise<void> {
   const db = getDb();
   db.prepare(
     `INSERT INTO dynamic_channels (channel_id, platform, name, bot, working_directory, agent, model, trigger_mode, threaded_replies, verbose, is_dm)
@@ -528,19 +514,19 @@ export function addDynamicChannel(channel: Omit<DynamicChannel, 'createdAt' | 'u
   );
 }
 
-export function removeDynamicChannel(channelId: string): void {
+export async function removeDynamicChannel(channelId: string): Promise<void> {
   const db = getDb();
   db.prepare('DELETE FROM dynamic_channels WHERE channel_id = ?').run(channelId);
 }
 
-export function getDynamicChannel(channelId: string): DynamicChannel | null {
+export async function getDynamicChannel(channelId: string): Promise<DynamicChannel | null> {
   const db = getDb();
   const row = db.prepare('SELECT * FROM dynamic_channels WHERE channel_id = ?').get(channelId) as any;
   if (!row) return null;
   return mapDynamicChannelRow(row);
 }
 
-export function getDynamicChannels(): DynamicChannel[] {
+export async function getDynamicChannels(): Promise<DynamicChannel[]> {
   const db = getDb();
   const rows = db.prepare('SELECT * FROM dynamic_channels ORDER BY created_at').all() as any[];
   return rows.map(mapDynamicChannelRow);
@@ -579,7 +565,7 @@ export interface AgentCallRecord {
   depth?: number;
 }
 
-export function recordAgentCall(record: AgentCallRecord): void {
+export async function recordAgentCall(record: AgentCallRecord): Promise<void> {
   const db = getDb();
   db.prepare(
     `INSERT INTO agent_calls (caller_bot, target_bot, target_agent, message_summary, response_summary, duration_ms, success, error, chain_id, depth)
@@ -598,7 +584,7 @@ export function recordAgentCall(record: AgentCallRecord): void {
   );
 }
 
-export function getRecentAgentCalls(limit: number = 20): Array<AgentCallRecord & { id: number; createdAt: string }> {
+export async function getRecentAgentCalls(limit: number = 20): Promise<Array<AgentCallRecord & { id: number; createdAt: string }>> {
   const db = getDb();
   const rows = db.prepare(
     'SELECT * FROM agent_calls ORDER BY created_at DESC LIMIT ?'
@@ -637,7 +623,7 @@ export interface ScheduledTask {
   createdAt: string;
 }
 
-export function insertScheduledTask(task: Omit<ScheduledTask, 'createdAt' | 'lastRun' | 'nextRun'> & { nextRun?: string }): void {
+export async function insertScheduledTask(task: Omit<ScheduledTask, 'createdAt' | 'lastRun' | 'nextRun'> & { nextRun?: string }): Promise<void> {
   const db = getDb();
   db.prepare(`
     INSERT INTO scheduled_tasks (id, channel_id, bot_name, prompt, cron_expr, run_at, timezone, created_by, description, enabled, next_run)
@@ -650,13 +636,13 @@ export function insertScheduledTask(task: Omit<ScheduledTask, 'createdAt' | 'las
   );
 }
 
-export function getScheduledTask(id: string): ScheduledTask | null {
+export async function getScheduledTask(id: string): Promise<ScheduledTask | null> {
   const db = getDb();
   const row = db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as any;
   return row ? mapTaskRow(row) : null;
 }
 
-export function getScheduledTasksForChannel(channelId: string): ScheduledTask[] {
+export async function getScheduledTasksForChannel(channelId: string): Promise<ScheduledTask[]> {
   const db = getDb();
   // Show enabled tasks + paused recurring tasks (exclude disabled one-offs — they're finished)
   const rows = db.prepare(
@@ -665,23 +651,23 @@ export function getScheduledTasksForChannel(channelId: string): ScheduledTask[] 
   return rows.map(mapTaskRow);
 }
 
-export function getEnabledScheduledTasks(): ScheduledTask[] {
+export async function getEnabledScheduledTasks(): Promise<ScheduledTask[]> {
   const db = getDb();
   const rows = db.prepare('SELECT * FROM scheduled_tasks WHERE enabled = 1').all() as any[];
   return rows.map(mapTaskRow);
 }
 
-export function updateScheduledTaskEnabled(id: string, enabled: boolean): void {
+export async function updateScheduledTaskEnabled(id: string, enabled: boolean): Promise<void> {
   const db = getDb();
   db.prepare('UPDATE scheduled_tasks SET enabled = ? WHERE id = ?').run(enabled ? 1 : 0, id);
 }
 
-export function updateScheduledTaskLastRun(id: string, lastRun: string, nextRun?: string): void {
+export async function updateScheduledTaskLastRun(id: string, lastRun: string, nextRun?: string): Promise<void> {
   const db = getDb();
   db.prepare('UPDATE scheduled_tasks SET last_run = ?, next_run = ? WHERE id = ?').run(lastRun, nextRun ?? null, id);
 }
 
-export function deleteScheduledTask(id: string): void {
+export async function deleteScheduledTask(id: string): Promise<void> {
   const db = getDb();
   db.prepare('DELETE FROM scheduled_tasks WHERE id = ?').run(id);
 }
@@ -718,7 +704,7 @@ export interface TaskHistoryEntry {
   error?: string;
 }
 
-export function insertTaskHistory(entry: Omit<TaskHistoryEntry, 'id' | 'firedAt'>): void {
+export async function insertTaskHistory(entry: Omit<TaskHistoryEntry, 'id' | 'firedAt'>): Promise<void> {
   const db = getDb();
   db.prepare(`
     INSERT INTO scheduled_task_history (task_id, channel_id, prompt, description, timezone, status, fired_at, error)
@@ -726,7 +712,7 @@ export function insertTaskHistory(entry: Omit<TaskHistoryEntry, 'id' | 'firedAt'
   `).run(entry.taskId, entry.channelId, entry.prompt, entry.description ?? null, entry.timezone, entry.status, entry.error ?? null);
 }
 
-export function getTaskHistory(channelId: string, limit = 20): TaskHistoryEntry[] {
+export async function getTaskHistory(channelId: string, limit = 20): Promise<TaskHistoryEntry[]> {
   const db = getDb();
   const rows = db.prepare(
     'SELECT * FROM scheduled_task_history WHERE channel_id = ? ORDER BY fired_at DESC LIMIT ?'
@@ -746,7 +732,7 @@ export function getTaskHistory(channelId: string, limit = 20): TaskHistoryEntry[
 
 // --- Cleanup ---
 
-export function closeDb(): void {
+export async function closeDb(): Promise<void> {
   _db?.close();
   _db = null;
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -2,10 +2,23 @@ import Database from 'better-sqlite3';
 import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
+import { performance } from 'node:perf_hooks';
 import { createLogger } from '../logger.js';
 
 const log = createLogger('store');
 const DB_PATH = path.join(os.homedir(), '.copilot-bridge', 'state.db');
+const SLOW_QUERY_MS = 50;
+
+/** Classify SQLite error codes into severity buckets for logging. */
+function classifyDbError(err: unknown): 'busy' | 'corrupt' | 'full' | 'readonly' | 'other' {
+  const code = (err as any)?.code as string | undefined;
+  if (!code) return 'other';
+  if (code === 'SQLITE_BUSY' || code.startsWith('SQLITE_BUSY_')) return 'busy';
+  if (code === 'SQLITE_CORRUPT' || code.startsWith('SQLITE_CORRUPT_')) return 'corrupt';
+  if (code === 'SQLITE_FULL') return 'full';
+  if (code === 'SQLITE_READONLY' || code.startsWith('SQLITE_READONLY_')) return 'readonly';
+  return 'other';
+}
 
 function safeParseStringArray(raw: string): string[] | undefined {
   try {
@@ -230,44 +243,76 @@ function getDb(): Database.Database {
 
 export async function getChannelSession(channelId: string): Promise<string | null> {
   try {
+    const start = performance.now();
     const db = getDb();
     const row = db.prepare('SELECT session_id FROM channel_sessions WHERE channel_id = ?').get(channelId) as { session_id: string } | undefined;
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getChannelSession took ${elapsed.toFixed(0)}ms`);
     return row?.session_id ?? null;
   } catch (err) {
-    log.error('getChannelSession failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getChannelSession CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getChannelSession CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getChannelSession - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getChannelSession - database is read-only:', err);
+    else log.error('getChannelSession failed:', err);
     throw err;
   }
 }
 
 export async function setChannelSession(channelId: string, sessionId: string): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare(
       'INSERT OR REPLACE INTO channel_sessions (channel_id, session_id, created_at) VALUES (?, ?, datetime(\'now\'))'
     ).run(channelId, sessionId);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`setChannelSession took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('setChannelSession failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('setChannelSession CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('setChannelSession CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('setChannelSession - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('setChannelSession - database is read-only:', err);
+    else log.error('setChannelSession failed:', err);
     throw err;
   }
 }
 
 export async function clearChannelSession(channelId: string): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare('DELETE FROM channel_sessions WHERE channel_id = ?').run(channelId);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`clearChannelSession took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('clearChannelSession failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('clearChannelSession CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('clearChannelSession CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('clearChannelSession - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('clearChannelSession - database is read-only:', err);
+    else log.error('clearChannelSession failed:', err);
     throw err;
   }
 }
 
 export async function getAllChannelSessions(): Promise<Array<{ channelId: string; sessionId: string }>> {
   try {
+    const start = performance.now();
     const db = getDb();
     const rows = db.prepare('SELECT channel_id, session_id FROM channel_sessions').all() as any[];
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getAllChannelSessions took ${elapsed.toFixed(0)}ms`);
     return rows.map(r => ({ channelId: r.channel_id, sessionId: r.session_id }));
   } catch (err) {
-    log.error('getAllChannelSessions failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getAllChannelSessions CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getAllChannelSessions CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getAllChannelSessions - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getAllChannelSessions - database is read-only:', err);
+    else log.error('getAllChannelSessions failed:', err);
     throw err;
   }
 }
@@ -289,8 +334,11 @@ export interface ChannelPrefs {
 
 export async function getChannelPrefs(channelId: string): Promise<ChannelPrefs | null> {
   try {
+    const start = performance.now();
     const db = getDb();
     const row = db.prepare('SELECT * FROM channel_prefs WHERE channel_id = ?').get(channelId) as any;
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getChannelPrefs took ${elapsed.toFixed(0)}ms`);
     if (!row) return null;
     return {
       model: row.model ?? undefined,
@@ -305,41 +353,58 @@ export async function getChannelPrefs(channelId: string): Promise<ChannelPrefs |
       disabledSkills: row.disabled_skills ? safeParseStringArray(row.disabled_skills) : undefined,
     };
   } catch (err) {
-    log.error('getChannelPrefs failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getChannelPrefs CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getChannelPrefs CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getChannelPrefs - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getChannelPrefs - database is read-only:', err);
+    else log.error('getChannelPrefs failed:', err);
     throw err;
   }
 }
 
 export async function setChannelPrefs(channelId: string, prefs: Partial<ChannelPrefs>): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
 
-    // Ensure a row exists (upsert-safe — avoids TOCTOU race with async callers)
-    db.prepare(
-      `INSERT OR IGNORE INTO channel_prefs (channel_id) VALUES (?)`
-    ).run(channelId);
+    const txn = db.transaction(() => {
+      // Ensure a row exists (upsert-safe — avoids TOCTOU race with async callers)
+      db.prepare(
+        `INSERT OR IGNORE INTO channel_prefs (channel_id) VALUES (?)`
+      ).run(channelId);
 
-    const updates: string[] = [];
-    const values: any[] = [];
+      const updates: string[] = [];
+      const values: any[] = [];
 
-    if (prefs.model !== undefined) { updates.push('model = ?'); values.push(prefs.model); }
-    if (prefs.provider !== undefined) { updates.push('provider = ?'); values.push(prefs.provider); }
-    if (prefs.agent !== undefined) { updates.push('agent = ?'); values.push(prefs.agent); }
-    if (prefs.verbose !== undefined) { updates.push('verbose = ?'); values.push(prefs.verbose ? 1 : 0); }
+      if (prefs.model !== undefined) { updates.push('model = ?'); values.push(prefs.model); }
+      if (prefs.provider !== undefined) { updates.push('provider = ?'); values.push(prefs.provider); }
+      if (prefs.agent !== undefined) { updates.push('agent = ?'); values.push(prefs.agent); }
+      if (prefs.verbose !== undefined) { updates.push('verbose = ?'); values.push(prefs.verbose ? 1 : 0); }
 
-    if (prefs.threadedReplies !== undefined) { updates.push('threaded_replies = ?'); values.push(prefs.threadedReplies ? 1 : 0); }
-    if (prefs.permissionMode !== undefined) { updates.push('permission_mode = ?'); values.push(prefs.permissionMode); }
-    if (prefs.reasoningEffort !== undefined) { updates.push('reasoning_effort = ?'); values.push(prefs.reasoningEffort); }
-    if (prefs.sessionMode !== undefined) { updates.push('session_mode = ?'); values.push(prefs.sessionMode); }
-    if (prefs.disabledSkills !== undefined) { updates.push('disabled_skills = ?'); values.push(JSON.stringify(prefs.disabledSkills)); }
+      if (prefs.threadedReplies !== undefined) { updates.push('threaded_replies = ?'); values.push(prefs.threadedReplies ? 1 : 0); }
+      if (prefs.permissionMode !== undefined) { updates.push('permission_mode = ?'); values.push(prefs.permissionMode); }
+      if (prefs.reasoningEffort !== undefined) { updates.push('reasoning_effort = ?'); values.push(prefs.reasoningEffort); }
+      if (prefs.sessionMode !== undefined) { updates.push('session_mode = ?'); values.push(prefs.sessionMode); }
+      if (prefs.disabledSkills !== undefined) { updates.push('disabled_skills = ?'); values.push(JSON.stringify(prefs.disabledSkills)); }
 
-    if (updates.length > 0) {
-      updates.push("updated_at = datetime('now')");
-      values.push(channelId);
-      db.prepare(`UPDATE channel_prefs SET ${updates.join(', ')} WHERE channel_id = ?`).run(...values);
-    }
+      if (updates.length > 0) {
+        updates.push("updated_at = datetime('now')");
+        values.push(channelId);
+        db.prepare(`UPDATE channel_prefs SET ${updates.join(', ')} WHERE channel_id = ?`).run(...values);
+      }
+    });
+    txn();
+
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`setChannelPrefs took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('setChannelPrefs failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('setChannelPrefs CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('setChannelPrefs CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('setChannelPrefs - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('setChannelPrefs - database is read-only:', err);
+    else log.error('setChannelPrefs failed:', err);
     throw err;
   }
 }
@@ -357,10 +422,13 @@ export interface StoredPermissionRule {
 
 export async function getPermissionRules(scope: string, tool: string): Promise<StoredPermissionRule[]> {
   try {
+    const start = performance.now();
     const db = getDb();
     const rows = db.prepare(
       'SELECT * FROM permission_rules WHERE (scope = ? OR scope = \'global\') AND tool = ? ORDER BY scope DESC, id DESC'
     ).all(scope, tool) as any[];
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getPermissionRules took ${elapsed.toFixed(0)}ms`);
     return rows.map(r => ({
       id: r.id,
       scope: r.scope,
@@ -370,34 +438,60 @@ export async function getPermissionRules(scope: string, tool: string): Promise<S
       createdAt: r.created_at,
     }));
   } catch (err) {
-    log.error('getPermissionRules failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getPermissionRules CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getPermissionRules CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getPermissionRules - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getPermissionRules - database is read-only:', err);
+    else log.error('getPermissionRules failed:', err);
     throw err;
   }
 }
 
 export async function addPermissionRule(scope: string, tool: string, commandPattern: string, action: 'allow' | 'deny'): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
-    // Remove existing rule for same scope+tool+pattern before inserting
-    db.prepare(
-      'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
-    ).run(scope, tool, commandPattern);
 
-    db.prepare(
-      'INSERT INTO permission_rules (scope, tool, command_pattern, action) VALUES (?, ?, ?, ?)'
-    ).run(scope, tool, commandPattern, action);
+    const txn = db.transaction(() => {
+      // Remove existing rule for same scope+tool+pattern before inserting
+      db.prepare(
+        'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
+      ).run(scope, tool, commandPattern);
+
+      db.prepare(
+        'INSERT INTO permission_rules (scope, tool, command_pattern, action) VALUES (?, ?, ?, ?)'
+      ).run(scope, tool, commandPattern, action);
+    });
+    txn();
+
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`addPermissionRule took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('addPermissionRule failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('addPermissionRule CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('addPermissionRule CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('addPermissionRule - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('addPermissionRule - database is read-only:', err);
+    else log.error('addPermissionRule failed:', err);
     throw err;
   }
 }
 
 export async function clearPermissionRules(scope: string): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare('DELETE FROM permission_rules WHERE scope = ?').run(scope);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`clearPermissionRules took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('clearPermissionRules failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('clearPermissionRules CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('clearPermissionRules CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('clearPermissionRules - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('clearPermissionRules - database is read-only:', err);
+    else log.error('clearPermissionRules failed:', err);
     throw err;
   }
 }
@@ -405,13 +499,21 @@ export async function clearPermissionRules(scope: string): Promise<void> {
 /** Remove a specific permission rule by scope + tool + command_pattern. */
 export async function removePermissionRule(scope: string, tool: string, commandPattern: string): Promise<boolean> {
   try {
+    const start = performance.now();
     const db = getDb();
     const result = db.prepare(
       'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
     ).run(scope, tool, commandPattern);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`removePermissionRule took ${elapsed.toFixed(0)}ms`);
     return result.changes > 0;
   } catch (err) {
-    log.error('removePermissionRule failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('removePermissionRule CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('removePermissionRule CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('removePermissionRule - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('removePermissionRule - database is read-only:', err);
+    else log.error('removePermissionRule failed:', err);
     throw err;
   }
 }
@@ -419,10 +521,13 @@ export async function removePermissionRule(scope: string, tool: string, commandP
 /** List all permission rules for a scope. */
 export async function listPermissionRulesForScope(scope: string): Promise<StoredPermissionRule[]> {
   try {
+    const start = performance.now();
     const db = getDb();
     const rows = db.prepare(
       'SELECT * FROM permission_rules WHERE scope = ? ORDER BY tool, command_pattern'
     ).all(scope) as any[];
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`listPermissionRulesForScope took ${elapsed.toFixed(0)}ms`);
     return rows.map(r => ({
       id: r.id,
       scope: r.scope,
@@ -432,7 +537,12 @@ export async function listPermissionRulesForScope(scope: string): Promise<Stored
       createdAt: r.created_at,
     }));
   } catch (err) {
-    log.error('listPermissionRulesForScope failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('listPermissionRulesForScope CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('listPermissionRulesForScope CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('listPermissionRulesForScope - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('listPermissionRulesForScope - database is read-only:', err);
+    else log.error('listPermissionRulesForScope failed:', err);
     throw err;
   }
 }
@@ -474,8 +584,11 @@ function safeParseAllowPaths(raw: string): string[] {
 
 export async function getWorkspaceOverride(botName: string): Promise<WorkspaceOverride | null> {
   try {
+    const start = performance.now();
     const db = getDb();
     const row = db.prepare('SELECT * FROM workspace_overrides WHERE bot_name = ?').get(botName) as any;
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getWorkspaceOverride took ${elapsed.toFixed(0)}ms`);
     if (!row) return null;
     return {
       botName: row.bot_name,
@@ -484,13 +597,19 @@ export async function getWorkspaceOverride(botName: string): Promise<WorkspaceOv
       createdAt: row.created_at,
     };
   } catch (err) {
-    log.error('getWorkspaceOverride failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getWorkspaceOverride CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getWorkspaceOverride CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getWorkspaceOverride - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getWorkspaceOverride - database is read-only:', err);
+    else log.error('getWorkspaceOverride failed:', err);
     throw err;
   }
 }
 
 export async function setWorkspaceOverride(botName: string, workingDirectory: string, allowPaths?: string[]): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare(
       `INSERT INTO workspace_overrides (bot_name, working_directory, allow_paths, created_at)
@@ -499,26 +618,44 @@ export async function setWorkspaceOverride(botName: string, workingDirectory: st
          working_directory = excluded.working_directory,
          allow_paths = excluded.allow_paths`
     ).run(botName, workingDirectory, JSON.stringify(allowPaths ?? []));
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`setWorkspaceOverride took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('setWorkspaceOverride failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('setWorkspaceOverride CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('setWorkspaceOverride CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('setWorkspaceOverride - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('setWorkspaceOverride - database is read-only:', err);
+    else log.error('setWorkspaceOverride failed:', err);
     throw err;
   }
 }
 
 export async function removeWorkspaceOverride(botName: string): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare('DELETE FROM workspace_overrides WHERE bot_name = ?').run(botName);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`removeWorkspaceOverride took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('removeWorkspaceOverride failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('removeWorkspaceOverride CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('removeWorkspaceOverride CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('removeWorkspaceOverride - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('removeWorkspaceOverride - database is read-only:', err);
+    else log.error('removeWorkspaceOverride failed:', err);
     throw err;
   }
 }
 
 export async function listWorkspaceOverrides(): Promise<WorkspaceOverride[]> {
   try {
+    const start = performance.now();
     const db = getDb();
     const rows = db.prepare('SELECT * FROM workspace_overrides').all() as any[];
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`listWorkspaceOverrides took ${elapsed.toFixed(0)}ms`);
     return rows.map(row => ({
       botName: row.bot_name,
       workingDirectory: row.working_directory,
@@ -526,7 +663,12 @@ export async function listWorkspaceOverrides(): Promise<WorkspaceOverride[]> {
       createdAt: row.created_at,
     }));
   } catch (err) {
-    log.error('listWorkspaceOverrides failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('listWorkspaceOverrides CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('listWorkspaceOverrides CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('listWorkspaceOverrides - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('listWorkspaceOverrides - database is read-only:', err);
+    else log.error('listWorkspaceOverrides failed:', err);
     throw err;
   }
 }
@@ -535,24 +677,40 @@ export async function listWorkspaceOverrides(): Promise<WorkspaceOverride[]> {
 
 export async function getGlobalSetting(key: string): Promise<string | null> {
   try {
+    const start = performance.now();
     const db = getDb();
     const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getGlobalSetting took ${elapsed.toFixed(0)}ms`);
     return row?.value ?? null;
   } catch (err) {
-    log.error('getGlobalSetting failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getGlobalSetting CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getGlobalSetting CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getGlobalSetting - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getGlobalSetting - database is read-only:', err);
+    else log.error('getGlobalSetting failed:', err);
     throw err;
   }
 }
 
 export async function setGlobalSetting(key: string, value: string): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare(
       `INSERT INTO settings (key, value) VALUES (?, ?)
        ON CONFLICT(key) DO UPDATE SET value = excluded.value`
     ).run(key, value);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`setGlobalSetting took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('setGlobalSetting failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('setGlobalSetting CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('setGlobalSetting CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('setGlobalSetting - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('setGlobalSetting - database is read-only:', err);
+    else log.error('setGlobalSetting failed:', err);
     throw err;
   }
 }
@@ -577,6 +735,7 @@ export interface DynamicChannel {
 
 export async function addDynamicChannel(channel: Omit<DynamicChannel, 'createdAt' | 'updatedAt'>): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare(
       `INSERT INTO dynamic_channels (channel_id, platform, name, bot, working_directory, agent, model, trigger_mode, threaded_replies, verbose, is_dm)
@@ -600,41 +759,72 @@ export async function addDynamicChannel(channel: Omit<DynamicChannel, 'createdAt
       channel.verbose != null ? (channel.verbose ? 1 : 0) : null,
       channel.isDM ? 1 : 0,
     );
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`addDynamicChannel took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('addDynamicChannel failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('addDynamicChannel CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('addDynamicChannel CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('addDynamicChannel - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('addDynamicChannel - database is read-only:', err);
+    else log.error('addDynamicChannel failed:', err);
     throw err;
   }
 }
 
 export async function removeDynamicChannel(channelId: string): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare('DELETE FROM dynamic_channels WHERE channel_id = ?').run(channelId);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`removeDynamicChannel took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('removeDynamicChannel failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('removeDynamicChannel CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('removeDynamicChannel CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('removeDynamicChannel - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('removeDynamicChannel - database is read-only:', err);
+    else log.error('removeDynamicChannel failed:', err);
     throw err;
   }
 }
 
 export async function getDynamicChannel(channelId: string): Promise<DynamicChannel | null> {
   try {
+    const start = performance.now();
     const db = getDb();
     const row = db.prepare('SELECT * FROM dynamic_channels WHERE channel_id = ?').get(channelId) as any;
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getDynamicChannel took ${elapsed.toFixed(0)}ms`);
     if (!row) return null;
     return mapDynamicChannelRow(row);
   } catch (err) {
-    log.error('getDynamicChannel failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getDynamicChannel CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getDynamicChannel CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getDynamicChannel - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getDynamicChannel - database is read-only:', err);
+    else log.error('getDynamicChannel failed:', err);
     throw err;
   }
 }
 
 export async function getDynamicChannels(): Promise<DynamicChannel[]> {
   try {
+    const start = performance.now();
     const db = getDb();
     const rows = db.prepare('SELECT * FROM dynamic_channels ORDER BY created_at').all() as any[];
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getDynamicChannels took ${elapsed.toFixed(0)}ms`);
     return rows.map(mapDynamicChannelRow);
   } catch (err) {
-    log.error('getDynamicChannels failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getDynamicChannels CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getDynamicChannels CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getDynamicChannels - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getDynamicChannels - database is read-only:', err);
+    else log.error('getDynamicChannels failed:', err);
     throw err;
   }
 }
@@ -674,6 +864,7 @@ export interface AgentCallRecord {
 
 export async function recordAgentCall(record: AgentCallRecord): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare(
       `INSERT INTO agent_calls (caller_bot, target_bot, target_agent, message_summary, response_summary, duration_ms, success, error, chain_id, depth)
@@ -690,18 +881,28 @@ export async function recordAgentCall(record: AgentCallRecord): Promise<void> {
       record.chainId ?? null,
       record.depth ?? 0,
     );
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`recordAgentCall took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('recordAgentCall failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('recordAgentCall CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('recordAgentCall CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('recordAgentCall - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('recordAgentCall - database is read-only:', err);
+    else log.error('recordAgentCall failed:', err);
     throw err;
   }
 }
 
 export async function getRecentAgentCalls(limit: number = 20): Promise<Array<AgentCallRecord & { id: number; createdAt: string }>> {
   try {
+    const start = performance.now();
     const db = getDb();
     const rows = db.prepare(
       'SELECT * FROM agent_calls ORDER BY created_at DESC LIMIT ?'
     ).all(limit) as any[];
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getRecentAgentCalls took ${elapsed.toFixed(0)}ms`);
     return rows.map(r => ({
       id: r.id,
       callerBot: r.caller_bot,
@@ -717,7 +918,12 @@ export async function getRecentAgentCalls(limit: number = 20): Promise<Array<Age
       createdAt: r.created_at,
     }));
   } catch (err) {
-    log.error('getRecentAgentCalls failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getRecentAgentCalls CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getRecentAgentCalls CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getRecentAgentCalls - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getRecentAgentCalls - database is read-only:', err);
+    else log.error('getRecentAgentCalls failed:', err);
     throw err;
   }
 }
@@ -742,6 +948,7 @@ export interface ScheduledTask {
 
 export async function insertScheduledTask(task: Omit<ScheduledTask, 'createdAt' | 'lastRun' | 'nextRun'> & { nextRun?: string }): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare(`
       INSERT INTO scheduled_tasks (id, channel_id, bot_name, prompt, cron_expr, run_at, timezone, created_by, description, enabled, next_run)
@@ -752,74 +959,129 @@ export async function insertScheduledTask(task: Omit<ScheduledTask, 'createdAt' 
       task.createdBy ?? null, task.description ?? null,
       task.enabled ? 1 : 0, task.nextRun ?? null,
     );
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`insertScheduledTask took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('insertScheduledTask failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('insertScheduledTask CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('insertScheduledTask CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('insertScheduledTask - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('insertScheduledTask - database is read-only:', err);
+    else log.error('insertScheduledTask failed:', err);
     throw err;
   }
 }
 
 export async function getScheduledTask(id: string): Promise<ScheduledTask | null> {
   try {
+    const start = performance.now();
     const db = getDb();
     const row = db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as any;
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getScheduledTask took ${elapsed.toFixed(0)}ms`);
     return row ? mapTaskRow(row) : null;
   } catch (err) {
-    log.error('getScheduledTask failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getScheduledTask CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getScheduledTask CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getScheduledTask - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getScheduledTask - database is read-only:', err);
+    else log.error('getScheduledTask failed:', err);
     throw err;
   }
 }
 
 export async function getScheduledTasksForChannel(channelId: string): Promise<ScheduledTask[]> {
   try {
+    const start = performance.now();
     const db = getDb();
     // Show enabled tasks + paused recurring tasks (exclude disabled one-offs — they're finished)
     const rows = db.prepare(
       'SELECT * FROM scheduled_tasks WHERE channel_id = ? AND (enabled = 1 OR cron_expr IS NOT NULL) ORDER BY created_at DESC'
     ).all(channelId) as any[];
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getScheduledTasksForChannel took ${elapsed.toFixed(0)}ms`);
     return rows.map(mapTaskRow);
   } catch (err) {
-    log.error('getScheduledTasksForChannel failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getScheduledTasksForChannel CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getScheduledTasksForChannel CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getScheduledTasksForChannel - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getScheduledTasksForChannel - database is read-only:', err);
+    else log.error('getScheduledTasksForChannel failed:', err);
     throw err;
   }
 }
 
 export async function getEnabledScheduledTasks(): Promise<ScheduledTask[]> {
   try {
+    const start = performance.now();
     const db = getDb();
     const rows = db.prepare('SELECT * FROM scheduled_tasks WHERE enabled = 1').all() as any[];
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getEnabledScheduledTasks took ${elapsed.toFixed(0)}ms`);
     return rows.map(mapTaskRow);
   } catch (err) {
-    log.error('getEnabledScheduledTasks failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getEnabledScheduledTasks CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getEnabledScheduledTasks CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getEnabledScheduledTasks - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getEnabledScheduledTasks - database is read-only:', err);
+    else log.error('getEnabledScheduledTasks failed:', err);
     throw err;
   }
 }
 
 export async function updateScheduledTaskEnabled(id: string, enabled: boolean): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare('UPDATE scheduled_tasks SET enabled = ? WHERE id = ?').run(enabled ? 1 : 0, id);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`updateScheduledTaskEnabled took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('updateScheduledTaskEnabled failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('updateScheduledTaskEnabled CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('updateScheduledTaskEnabled CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('updateScheduledTaskEnabled - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('updateScheduledTaskEnabled - database is read-only:', err);
+    else log.error('updateScheduledTaskEnabled failed:', err);
     throw err;
   }
 }
 
 export async function updateScheduledTaskLastRun(id: string, lastRun: string, nextRun?: string): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare('UPDATE scheduled_tasks SET last_run = ?, next_run = ? WHERE id = ?').run(lastRun, nextRun ?? null, id);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`updateScheduledTaskLastRun took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('updateScheduledTaskLastRun failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('updateScheduledTaskLastRun CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('updateScheduledTaskLastRun CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('updateScheduledTaskLastRun - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('updateScheduledTaskLastRun - database is read-only:', err);
+    else log.error('updateScheduledTaskLastRun failed:', err);
     throw err;
   }
 }
 
 export async function deleteScheduledTask(id: string): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare('DELETE FROM scheduled_tasks WHERE id = ?').run(id);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`deleteScheduledTask took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('deleteScheduledTask failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('deleteScheduledTask CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('deleteScheduledTask CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('deleteScheduledTask - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('deleteScheduledTask - database is read-only:', err);
+    else log.error('deleteScheduledTask failed:', err);
     throw err;
   }
 }
@@ -858,23 +1120,34 @@ export interface TaskHistoryEntry {
 
 export async function insertTaskHistory(entry: Omit<TaskHistoryEntry, 'id' | 'firedAt'>): Promise<void> {
   try {
+    const start = performance.now();
     const db = getDb();
     db.prepare(`
       INSERT INTO scheduled_task_history (task_id, channel_id, prompt, description, timezone, status, fired_at, error)
       VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)
     `).run(entry.taskId, entry.channelId, entry.prompt, entry.description ?? null, entry.timezone, entry.status, entry.error ?? null);
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`insertTaskHistory took ${elapsed.toFixed(0)}ms`);
   } catch (err) {
-    log.error('insertTaskHistory failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('insertTaskHistory CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('insertTaskHistory CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('insertTaskHistory - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('insertTaskHistory - database is read-only:', err);
+    else log.error('insertTaskHistory failed:', err);
     throw err;
   }
 }
 
 export async function getTaskHistory(channelId: string, limit = 20): Promise<TaskHistoryEntry[]> {
   try {
+    const start = performance.now();
     const db = getDb();
     const rows = db.prepare(
       'SELECT * FROM scheduled_task_history WHERE channel_id = ? ORDER BY fired_at DESC LIMIT ?'
     ).all(channelId, limit) as any[];
+    const elapsed = performance.now() - start;
+    if (elapsed > SLOW_QUERY_MS) log.warn(`getTaskHistory took ${elapsed.toFixed(0)}ms`);
     return rows.map(r => ({
       id: r.id,
       taskId: r.task_id,
@@ -887,7 +1160,12 @@ export async function getTaskHistory(channelId: string, limit = 20): Promise<Tas
       error: r.error ?? undefined,
     }));
   } catch (err) {
-    log.error('getTaskHistory failed:', err);
+    const kind = classifyDbError(err);
+    if (kind === 'corrupt') log.error('getTaskHistory CRITICAL - database may be corrupt:', err);
+    else if (kind === 'full') log.error('getTaskHistory CRITICAL - disk full:', err);
+    else if (kind === 'busy') log.warn('getTaskHistory - database busy (contention):', err);
+    else if (kind === 'readonly') log.error('getTaskHistory - database is read-only:', err);
+    else log.error('getTaskHistory failed:', err);
     throw err;
   }
 }


### PR DESCRIPTION
## Async State Store (PR 1 of 2 for #176)

Makes all 34 exported functions in `store.ts` async and adds database observability, preparing the state layer for a pluggable `StateStore` interface.

### Changes

**Async refactor:**
- All 34 store exports return `Promise<T>` (backed by `better-sqlite3` which resolves synchronously)
- All callers across 15 files updated with `await`
- `setChannelPrefs` refactored to `INSERT OR IGNORE + UPDATE` to avoid TOCTOU race

**Database observability:**
- Slow query warnings (>50ms) on all store functions
- Classified error logging -- SQLITE_BUSY (warn), SQLITE_CORRUPT/FULL (critical), READONLY (error)
- `setChannelPrefs` and `addPermissionRule` wrapped in transactions

**Error resilience:**
- `/schedule` and `/skill` commands show user-facing error messages on DB failure
- Double-fault protection in catch blocks (session cleanup, model revert)
- `handlePermissionRequest` falls through to interactive prompt on DB error
- `handleSessionEvent` falls back to defaults on prefs read failure
- Post-RPC store writes (model switch, agent switch, etc.) are best-effort -- DB failure doesn't mask a successful operation
- `resolvePermission` resolves the SDK callback before persisting rules

### Why

This is the prerequisite for PR 2, which will extract a `StateStore` interface and add plugin loading for custom backends (PostgreSQL, Redis, etc.). See #176 for the full plan.

### Risk

- Pure mechanical refactor + observability -- no behavioral changes except improved error handling
- TypeScript compiler enforces completeness (`Promise<T>` vs `T` mismatches catch every missed `await`)
- Reviewed by Opus, GPT-5.4, and CCR -- all findings addressed
- Tested live on the bridge for 1+ hour with zero store errors or slow queries
- 591/591 tests passing
