### PR TITLE
Pluggable StateStore interface (#176)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Use `createLogger(tag)` from `src/logger.ts`. Tags identify the subsystem (e.g.,
 
 ### State Persistence
 
-SQLite database at `~/.copilot-bridge/state.db` via `src/state/store.ts`. Uses WAL mode. Stores channel sessions, preferences, and permission rules.
+Pluggable state store via the `StateStore` interface (`src/state/types.ts`). The built-in default is `SqliteStateStore` (`src/state/sqlite-store.ts`), which uses SQLite at `~/.copilot-bridge/state.db` in WAL mode. `src/state/store.ts` is a thin facade that delegates to the active backend — all callers import from `store.ts` unchanged. Custom backends (Postgres, etc.) can be loaded via the `database.module` config option.
 
 ### Filing Issues
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -120,5 +120,10 @@
     "maxSize": 10485760,
     "maxFiles": 3,
     "compress": true
+  },
+  "_comment_database": "Optional: pluggable state store (default: built-in SQLite at ~/.copilot-bridge/state.db)",
+  "_example_database": {
+    "module": "./path/to/custom-store.js",
+    "options": { "connectionString": "postgresql://..." }
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,9 @@ src/
 │       ├── adapter.ts          # Mattermost WebSocket + REST adapter
 │       └── streaming.ts        # Edit-in-place streaming with throttle
 └── state/
-    └── store.ts                # SQLite persistence (sessions, prefs, permissions)
+    ├── types.ts              # StateStore interface + shared data types
+    ├── sqlite-store.ts       # SqliteStateStore (built-in default backend)
+    └── store.ts              # Thin facade — delegates to active StateStore
 ```
 
 ## Message flow
@@ -75,7 +77,9 @@ Optional methods:
 
 ## Persistence
 
-SQLite database at `~/.copilot-bridge/state.db` (WAL mode) via `src/state/store.ts`:
+The state layer uses a pluggable `StateStore` interface (`src/state/types.ts`). The built-in default is `SqliteStateStore` (`src/state/sqlite-store.ts`), which uses SQLite at `~/.copilot-bridge/state.db` (WAL mode). `src/state/store.ts` is a thin facade — callers import from it unchanged while the backing implementation can be swapped via `database.module` in config.
+
+Tables managed by the default SQLite backend:
 
 - **channel_sessions** — Maps channels to active Copilot session IDs
 - **channel_prefs** — Per-channel preferences (model, agent, verbose, trigger mode, reasoning effort, etc.)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -437,3 +437,21 @@ Hooks are loaded from multiple locations (lowest to highest priority). Commands 
 ### Viewing Loaded Hooks
 
 Use `/tools` in chat to see which hooks are currently loaded and how many commands are registered per hook type.
+
+## Database
+
+By default, the bridge uses SQLite at `~/.copilot-bridge/state.db`. The state layer is pluggable — you can swap in a custom backend (Postgres, Redis, etc.) by pointing `database.module` at a module that exports a class implementing the `StateStore` interface.
+
+```json
+{
+  "database": {
+    "module": "./path/to/custom-store.js",
+    "options": { "connectionString": "postgresql://..." }
+  }
+}
+```
+
+- **`module`** — Path to a JS module. Must export a class (default export or named) that implements `StateStore` from `src/state/types.ts`.
+- **`options`** — Arbitrary object passed to the custom store's constructor.
+
+When `database` is omitted (the default), the built-in `SqliteStateStore` is used with no additional configuration.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -451,7 +451,7 @@ By default, the bridge uses SQLite at `~/.copilot-bridge/state.db`. The state la
 }
 ```
 
-- **`module`** — Path to a JS module. Must export a class (default export or named) that implements `StateStore` from `src/state/types.ts`.
+- **`module`** — Path to a JS module. Must export a class (default export, named `StateStore` export, or the module itself) that implements the `StateStore` interface. See [StateStore interface](../src/state/types.ts) for the contract.
 - **`options`** — Arbitrary object passed to the custom store's constructor.
 
 When `database` is omitted (the default), the built-in `SqliteStateStore` is used with no additional configuration.

--- a/src/config.ts
+++ b/src/config.ts
@@ -258,6 +258,7 @@ function validateAndNormalize(raw: any): AppConfig {
     interAgent: raw.interAgent,
     providers: raw.providers,
     telemetry: raw.telemetry,
+    database: raw.database,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -258,10 +258,10 @@ function validateAndNormalize(raw: any): AppConfig {
     interAgent: raw.interAgent,
     providers: raw.providers,
     telemetry: raw.telemetry,
-    database: raw.database && typeof raw.database === 'object' ? {
-      module: typeof raw.database.module === 'string' ? raw.database.module : undefined,
+    database: raw.database && typeof raw.database === 'object' && typeof raw.database.module === 'string' ? {
+      module: raw.database.module,
       options: raw.database.options && typeof raw.database.options === 'object' ? raw.database.options : undefined,
-    } as DatabaseConfig : undefined,
+    } : (raw.database ? (() => { throw new Error('database.module must be a string when database config is present'); })() : undefined),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import type { AppConfig, ChannelConfig, BotConfig, PermissionsConfig, InterAgentConfig, AccessConfig, BridgeProviderConfig, LogRotationConfig } from './types.js';
+import type { AppConfig, ChannelConfig, BotConfig, PermissionsConfig, InterAgentConfig, AccessConfig, BridgeProviderConfig, LogRotationConfig, DatabaseConfig } from './types.js';
 import type { SDKProviderConfig } from './core/bridge.js';
 import { getDynamicChannel } from './state/store.js';
 import { createLogger } from './logger.js';
@@ -258,7 +258,10 @@ function validateAndNormalize(raw: any): AppConfig {
     interAgent: raw.interAgent,
     providers: raw.providers,
     telemetry: raw.telemetry,
-    database: raw.database,
+    database: raw.database && typeof raw.database === 'object' ? {
+      module: typeof raw.database.module === 'string' ? raw.database.module : undefined,
+      options: raw.database.options && typeof raw.database.options === 'object' ? raw.database.options : undefined,
+    } as DatabaseConfig : undefined,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { enterQuietMode, exitQuietMode, isQuiet } from './core/quiet-mode.js';
 import { createLogger, setLogLevel, initLogFile } from './logger.js';
 import fs from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import os from 'node:os';
 import type { ChannelAdapter, AdapterFactory, InboundMessage, InboundReaction, MessageAttachment, AppConfig, DatabaseConfig } from './types.js';
 
@@ -415,7 +416,11 @@ async function main(): Promise<void> {
       const modulePath = config.database.module.startsWith('.')
         ? path.resolve(process.cwd(), config.database.module)
         : config.database.module;
-      const mod = await import(modulePath);
+      // Use file:// URL for absolute paths (required by ESM on Windows)
+      const moduleSpecifier = path.isAbsolute(modulePath)
+        ? pathToFileURL(modulePath).href
+        : modulePath;
+      const mod = await import(moduleSpecifier);
       const StoreClass = mod.default ?? mod.StateStore ?? mod;
       if (typeof StoreClass !== 'function') {
         throw new Error(`Module does not export a constructor (got ${typeof StoreClass})`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -421,12 +421,17 @@ async function main(): Promise<void> {
         ? pathToFileURL(modulePath).href
         : modulePath;
       const mod = await import(moduleSpecifier);
-      const StoreClass = mod.default ?? mod.StateStore ?? mod;
-      if (typeof StoreClass !== 'function') {
-        throw new Error(`Module does not export a constructor (got ${typeof StoreClass})`);
+      const storeExport = mod.default ?? mod.StateStore ?? mod;
+      let customStore: StateStore;
+      if (typeof storeExport === 'function') {
+        customStore = new storeExport(config.database.options);
+      } else if (typeof storeExport === 'object' && storeExport !== null) {
+        // Accept a pre-constructed instance
+        customStore = storeExport as StateStore;
+      } else {
+        throw new Error(`Module does not export a constructor or StateStore instance (got ${typeof storeExport})`);
       }
-      const customStore: StateStore = new StoreClass(config.database.options);
-      // Validate required StateStore methods beyond just initialize()
+      // Validate required StateStore methods
       const required = ['initialize', 'close', 'ping', 'withTransaction', 'getChannelSession', 'setChannelPrefs', 'checkPermission', 'getChannelPrefs'];
       const missing = required.filter(m => typeof (customStore as any)[m] !== 'function');
       if (missing.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -410,9 +410,16 @@ async function main(): Promise<void> {
   // Initialize state store (must happen before any DB access)
   if (config.database?.module) {
     try {
+      log.info(`Loading custom state store from ${config.database.module}...`);
       const mod = await import(config.database.module);
       const StoreClass = mod.default ?? mod;
+      if (typeof StoreClass !== 'function') {
+        throw new Error(`Module does not export a constructor (got ${typeof StoreClass})`);
+      }
       const customStore: StateStore = new StoreClass(config.database.options);
+      if (typeof customStore.initialize !== 'function') {
+        throw new Error('Custom store does not implement StateStore.initialize()');
+      }
       await initStore(customStore);
       log.info(`Custom state store loaded from ${config.database.module}`);
     } catch (err) {
@@ -2518,6 +2525,6 @@ async function postRestartNotices(): Promise<void> {
 // Start the bridge
 main().catch(async (err) => {
   log.error('Fatal error:', err);
-  try { await closeDb(); } catch { /* best-effort */ }
+  try { await closeDb(); } catch (err) { log.warn('Failed to close database during fatal error handler:', err); }
   process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,14 +411,21 @@ async function main(): Promise<void> {
   if (config.database?.module) {
     try {
       log.info(`Loading custom state store from ${config.database.module}...`);
-      const mod = await import(config.database.module);
-      const StoreClass = mod.default ?? mod;
+      // Resolve relative paths against CWD, not the dist/ directory
+      const modulePath = config.database.module.startsWith('.')
+        ? path.resolve(process.cwd(), config.database.module)
+        : config.database.module;
+      const mod = await import(modulePath);
+      const StoreClass = mod.default ?? mod.StateStore ?? mod;
       if (typeof StoreClass !== 'function') {
         throw new Error(`Module does not export a constructor (got ${typeof StoreClass})`);
       }
       const customStore: StateStore = new StoreClass(config.database.options);
-      if (typeof customStore.initialize !== 'function') {
-        throw new Error('Custom store does not implement StateStore.initialize()');
+      // Validate required StateStore methods beyond just initialize()
+      const required = ['initialize', 'close', 'ping', 'getChannelSession', 'setChannelPrefs', 'checkPermission', 'getChannelPrefs'];
+      const missing = required.filter(m => typeof (customStore as any)[m] !== 'function');
+      if (missing.length > 0) {
+        throw new Error(`Custom store missing required methods: ${missing.join(', ')}`);
       }
       await initStore(customStore);
       log.info(`Custom state store loaded from ${config.database.module}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import { formatEvent, formatPermissionRequest, formatUserInputRequest } from './
 import { WorkspaceWatcher, initWorkspace, getWorkspacePath } from './core/workspace-manager.js';
 import { MattermostAdapter } from './channels/mattermost/adapter.js';
 import { StreamingHandler } from './channels/mattermost/streaming.js';
-import { getChannelPrefs, setChannelPrefs, getAllChannelSessions, closeDb, listPermissionRulesForScope, removePermissionRule, clearPermissionRules, getTaskHistory } from './state/store.js';
+import { initStore, getChannelPrefs, setChannelPrefs, getAllChannelSessions, closeDb, listPermissionRulesForScope, removePermissionRule, clearPermissionRules, getTaskHistory } from './state/store.js';
+import type { StateStore } from './state/types.js';
 import { extractThreadRequest, resolveThreadRoot } from './core/thread-utils.js';
 import { initScheduler, stopAll as stopScheduler, listJobs, removeJob, pauseJob, resumeJob, formatInTimezone, describeCron } from './core/scheduler.js';
 import { markBusy, markIdle, markIdleImmediate, isBusy, waitForChannelIdle, cancelIdleDebounce } from './core/channel-idle.js';
@@ -17,7 +18,7 @@ import { createLogger, setLogLevel, initLogFile } from './logger.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import type { ChannelAdapter, AdapterFactory, InboundMessage, InboundReaction, MessageAttachment, AppConfig } from './types.js';
+import type { ChannelAdapter, AdapterFactory, InboundMessage, InboundReaction, MessageAttachment, AppConfig, DatabaseConfig } from './types.js';
 
 const log = createLogger('bridge');
 
@@ -405,6 +406,22 @@ async function main(): Promise<void> {
     }
   });
   configWatcher.start();
+
+  // Initialize state store (must happen before any DB access)
+  if (config.database?.module) {
+    try {
+      const mod = await import(config.database.module);
+      const StoreClass = mod.default ?? mod;
+      const customStore: StateStore = new StoreClass(config.database.options);
+      await initStore(customStore);
+      log.info(`Custom state store loaded from ${config.database.module}`);
+    } catch (err) {
+      log.error(`Failed to load custom state store from ${config.database.module}:`, err);
+      process.exit(1);
+    }
+  } else {
+    await initStore();
+  }
 
   // Initialize Copilot SDK bridge
   const { telemetry: sdkTelemetry, env: telemetryEnv } = resolveTelemetryConfig(config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -427,7 +427,7 @@ async function main(): Promise<void> {
       }
       const customStore: StateStore = new StoreClass(config.database.options);
       // Validate required StateStore methods beyond just initialize()
-      const required = ['initialize', 'close', 'ping', 'getChannelSession', 'setChannelPrefs', 'checkPermission', 'getChannelPrefs'];
+      const required = ['initialize', 'close', 'ping', 'withTransaction', 'getChannelSession', 'setChannelPrefs', 'checkPermission', 'getChannelPrefs'];
       const missing = required.filter(m => typeof (customStore as any)[m] !== 'function');
       if (missing.length > 0) {
         throw new Error(`Custom store missing required methods: ${missing.join(', ')}`);

--- a/src/state/sqlite-store.test.ts
+++ b/src/state/sqlite-store.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SqliteStateStore } from './sqlite-store.js';
+
+describe('SqliteStateStore', () => {
+  let tmpDir: string;
+  let store: SqliteStateStore;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlite-store-'));
+    store = new SqliteStateStore(path.join(tmpDir, 'test.db'));
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await store.close().catch(() => {});
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ---- Lifecycle ----------------------------------------------------------
+
+  describe('lifecycle', () => {
+    it('constructor accepts custom dbPath', () => {
+      const s = new SqliteStateStore(path.join(tmpDir, 'custom.db'));
+      expect(s).toBeDefined();
+    });
+
+    it('initialize creates the DB file and tables', () => {
+      const dbFile = path.join(tmpDir, 'test.db');
+      expect(fs.existsSync(dbFile)).toBe(true);
+    });
+
+    it('ping returns true when open', async () => {
+      expect(await store.ping()).toBe(true);
+    });
+
+    it('ping returns false after close', async () => {
+      await store.close();
+      expect(await store.ping()).toBe(false);
+    });
+
+    it('close makes subsequent operations throw', async () => {
+      await store.close();
+      await expect(store.getChannelSession('ch1')).rejects.toThrow();
+    });
+  });
+
+  // ---- Sessions CRUD ------------------------------------------------------
+
+  describe('sessions', () => {
+    it('set and get a channel session', async () => {
+      await store.setChannelSession('ch1', 'sess-1');
+      expect(await store.getChannelSession('ch1')).toBe('sess-1');
+    });
+
+    it('get returns null for unknown channel', async () => {
+      expect(await store.getChannelSession('nope')).toBeNull();
+    });
+
+    it('set overwrites existing session', async () => {
+      await store.setChannelSession('ch1', 'sess-1');
+      await store.setChannelSession('ch1', 'sess-2');
+      expect(await store.getChannelSession('ch1')).toBe('sess-2');
+    });
+
+    it('clear removes the session', async () => {
+      await store.setChannelSession('ch1', 'sess-1');
+      await store.clearChannelSession('ch1');
+      expect(await store.getChannelSession('ch1')).toBeNull();
+    });
+
+    it('getAllChannelSessions returns all mappings', async () => {
+      await store.setChannelSession('ch1', 's1');
+      await store.setChannelSession('ch2', 's2');
+      const all = await store.getAllChannelSessions();
+      expect(all).toHaveLength(2);
+      expect(all).toEqual(
+        expect.arrayContaining([
+          { channelId: 'ch1', sessionId: 's1' },
+          { channelId: 'ch2', sessionId: 's2' },
+        ]),
+      );
+    });
+  });
+
+  // ---- Preferences CRUD ---------------------------------------------------
+
+  describe('preferences', () => {
+    it('get returns null when no prefs set', async () => {
+      expect(await store.getChannelPrefs('ch1')).toBeNull();
+    });
+
+    it('set and get prefs round-trip', async () => {
+      await store.setChannelPrefs('ch1', { model: 'gpt-4' });
+      const prefs = await store.getChannelPrefs('ch1');
+      expect(prefs?.model).toBe('gpt-4');
+    });
+
+    it('partial updates merge correctly', async () => {
+      await store.setChannelPrefs('ch1', { model: 'gpt-4' });
+      await store.setChannelPrefs('ch1', { verbose: true });
+      const prefs = await store.getChannelPrefs('ch1');
+      expect(prefs?.model).toBe('gpt-4');
+      expect(prefs?.verbose).toBe(true);
+    });
+
+    it('boolean fields round-trip correctly', async () => {
+      await store.setChannelPrefs('ch1', { verbose: false, threadedReplies: true });
+      const prefs = await store.getChannelPrefs('ch1');
+      expect(prefs?.verbose).toBe(false);
+      expect(prefs?.threadedReplies).toBe(true);
+    });
+
+    it('disabledSkills array serialization/deserialization', async () => {
+      await store.setChannelPrefs('ch1', { disabledSkills: ['skill-a', 'skill-b'] });
+      const prefs = await store.getChannelPrefs('ch1');
+      expect(prefs?.disabledSkills).toEqual(['skill-a', 'skill-b']);
+    });
+
+    it('provider field stores and retrieves null correctly', async () => {
+      await store.setChannelPrefs('ch1', { provider: 'openai' });
+      let prefs = await store.getChannelPrefs('ch1');
+      expect(prefs?.provider).toBe('openai');
+
+      await store.setChannelPrefs('ch1', { provider: null });
+      prefs = await store.getChannelPrefs('ch1');
+      expect(prefs?.provider).toBeNull();
+    });
+  });
+
+  // ---- Permissions --------------------------------------------------------
+
+  describe('permissions', () => {
+    it('add and get rules', async () => {
+      await store.addPermissionRule('global', 'bash', '*', 'allow');
+      const rules = await store.getPermissionRules('global', 'bash');
+      expect(rules).toHaveLength(1);
+      expect(rules[0].action).toBe('allow');
+      expect(rules[0].commandPattern).toBe('*');
+    });
+
+    it('checkPermission wildcard matching', async () => {
+      await store.addPermissionRule('global', 'bash', '*', 'allow');
+      expect(await store.checkPermission('global', 'bash', 'ls -la')).toBe('allow');
+    });
+
+    it('checkPermission exact match', async () => {
+      await store.addPermissionRule('global', 'bash', 'rm -rf /', 'deny');
+      expect(await store.checkPermission('global', 'bash', 'rm -rf /')).toBe('deny');
+    });
+
+    it('checkPermission returns null when no match', async () => {
+      await store.addPermissionRule('global', 'bash', 'specific-cmd', 'allow');
+      expect(await store.checkPermission('global', 'bash', 'other-cmd')).toBeNull();
+    });
+
+    it('addPermissionRule replaces existing rule for same scope+tool+pattern', async () => {
+      await store.addPermissionRule('global', 'bash', '*', 'allow');
+      await store.addPermissionRule('global', 'bash', '*', 'deny');
+      const rules = await store.getPermissionRules('global', 'bash');
+      expect(rules).toHaveLength(1);
+      expect(rules[0].action).toBe('deny');
+    });
+
+    it('clearPermissionRules removes all rules for a scope', async () => {
+      await store.addPermissionRule('global', 'bash', '*', 'allow');
+      await store.addPermissionRule('global', 'edit', '*', 'allow');
+      await store.clearPermissionRules('global');
+      expect(await store.listPermissionRulesForScope('global')).toHaveLength(0);
+    });
+
+    it('removePermissionRule removes a single rule', async () => {
+      await store.addPermissionRule('global', 'bash', '*', 'allow');
+      const removed = await store.removePermissionRule('global', 'bash', '*');
+      expect(removed).toBe(true);
+      expect(await store.getPermissionRules('global', 'bash')).toHaveLength(0);
+    });
+
+    it('removePermissionRule returns false when no match', async () => {
+      const removed = await store.removePermissionRule('global', 'bash', 'nope');
+      expect(removed).toBe(false);
+    });
+
+    it('listPermissionRulesForScope returns only that scope', async () => {
+      await store.addPermissionRule('global', 'bash', '*', 'allow');
+      await store.addPermissionRule('channel:ch1', 'bash', '*', 'deny');
+      const globalRules = await store.listPermissionRulesForScope('global');
+      expect(globalRules).toHaveLength(1);
+      expect(globalRules[0].scope).toBe('global');
+    });
+  });
+
+  // ---- Workspaces ---------------------------------------------------------
+
+  describe('workspaces', () => {
+    it('set and get workspace override', async () => {
+      await store.setWorkspaceOverride('bot1', '/home/bot1');
+      const ws = await store.getWorkspaceOverride('bot1');
+      expect(ws).not.toBeNull();
+      expect(ws!.botName).toBe('bot1');
+      expect(ws!.workingDirectory).toBe('/home/bot1');
+    });
+
+    it('get returns null for unknown bot', async () => {
+      expect(await store.getWorkspaceOverride('nope')).toBeNull();
+    });
+
+    it('allowPaths JSON serialization', async () => {
+      await store.setWorkspaceOverride('bot1', '/home/bot1', ['/data', '/logs']);
+      const ws = await store.getWorkspaceOverride('bot1');
+      expect(ws!.allowPaths).toEqual(['/data', '/logs']);
+    });
+
+    it('allowPaths defaults to empty array', async () => {
+      await store.setWorkspaceOverride('bot1', '/home/bot1');
+      const ws = await store.getWorkspaceOverride('bot1');
+      expect(ws!.allowPaths).toEqual([]);
+    });
+
+    it('remove workspace override', async () => {
+      await store.setWorkspaceOverride('bot1', '/home/bot1');
+      await store.removeWorkspaceOverride('bot1');
+      expect(await store.getWorkspaceOverride('bot1')).toBeNull();
+    });
+
+    it('list workspace overrides', async () => {
+      await store.setWorkspaceOverride('bot1', '/home/bot1');
+      await store.setWorkspaceOverride('bot2', '/home/bot2');
+      const all = await store.listWorkspaceOverrides();
+      expect(all).toHaveLength(2);
+    });
+
+    it('set upserts on conflict', async () => {
+      await store.setWorkspaceOverride('bot1', '/old');
+      await store.setWorkspaceOverride('bot1', '/new', ['/extra']);
+      const ws = await store.getWorkspaceOverride('bot1');
+      expect(ws!.workingDirectory).toBe('/new');
+      expect(ws!.allowPaths).toEqual(['/extra']);
+    });
+  });
+
+  // ---- Settings -----------------------------------------------------------
+
+  describe('settings', () => {
+    it('set and get global setting', async () => {
+      await store.setGlobalSetting('key1', 'value1');
+      expect(await store.getGlobalSetting('key1')).toBe('value1');
+    });
+
+    it('get returns null for unknown key', async () => {
+      expect(await store.getGlobalSetting('missing')).toBeNull();
+    });
+
+    it('upsert overwrites existing value', async () => {
+      await store.setGlobalSetting('key1', 'old');
+      await store.setGlobalSetting('key1', 'new');
+      expect(await store.getGlobalSetting('key1')).toBe('new');
+    });
+  });
+
+  // ---- Dynamic Channels ---------------------------------------------------
+
+  describe('dynamic channels', () => {
+    const baseChannel = {
+      channelId: 'dc1',
+      platform: 'mattermost',
+      name: 'test-channel',
+      workingDirectory: '/work',
+      isDM: false,
+    };
+
+    it('add and get dynamic channel', async () => {
+      await store.addDynamicChannel(baseChannel);
+      const ch = await store.getDynamicChannel('dc1');
+      expect(ch).not.toBeNull();
+      expect(ch!.channelId).toBe('dc1');
+      expect(ch!.platform).toBe('mattermost');
+      expect(ch!.name).toBe('test-channel');
+      expect(ch!.workingDirectory).toBe('/work');
+    });
+
+    it('get returns null for unknown channel', async () => {
+      expect(await store.getDynamicChannel('nope')).toBeNull();
+    });
+
+    it('remove dynamic channel', async () => {
+      await store.addDynamicChannel(baseChannel);
+      await store.removeDynamicChannel('dc1');
+      expect(await store.getDynamicChannel('dc1')).toBeNull();
+    });
+
+    it('list dynamic channels', async () => {
+      await store.addDynamicChannel(baseChannel);
+      await store.addDynamicChannel({ ...baseChannel, channelId: 'dc2', name: 'second' });
+      const all = await store.getDynamicChannels();
+      expect(all).toHaveLength(2);
+    });
+
+    it('boolean fields map correctly', async () => {
+      await store.addDynamicChannel({
+        ...baseChannel,
+        isDM: true,
+        verbose: true,
+        threadedReplies: false,
+      });
+      const ch = await store.getDynamicChannel('dc1');
+      expect(ch!.isDM).toBe(true);
+      expect(ch!.verbose).toBe(true);
+      expect(ch!.threadedReplies).toBe(false);
+    });
+
+    it('optional fields default correctly', async () => {
+      await store.addDynamicChannel(baseChannel);
+      const ch = await store.getDynamicChannel('dc1');
+      expect(ch!.bot).toBeUndefined();
+      expect(ch!.agent).toBeNull();
+      expect(ch!.model).toBeUndefined();
+      expect(ch!.verbose).toBeUndefined();
+      expect(ch!.threadedReplies).toBeUndefined();
+    });
+  });
+
+  // ---- Scheduled Tasks ----------------------------------------------------
+
+  describe('scheduled tasks', () => {
+    const baseTask = {
+      id: 'task-1',
+      channelId: 'ch1',
+      botName: 'bot1',
+      prompt: 'do something',
+      timezone: 'UTC',
+      enabled: true,
+    };
+
+    it('insert and get task', async () => {
+      await store.insertScheduledTask(baseTask);
+      const task = await store.getScheduledTask('task-1');
+      expect(task).not.toBeNull();
+      expect(task!.id).toBe('task-1');
+      expect(task!.prompt).toBe('do something');
+      expect(task!.enabled).toBe(true);
+    });
+
+    it('get returns null for unknown task', async () => {
+      expect(await store.getScheduledTask('nope')).toBeNull();
+    });
+
+    it('list tasks for channel', async () => {
+      await store.insertScheduledTask(baseTask);
+      await store.insertScheduledTask({ ...baseTask, id: 'task-2', channelId: 'ch2' });
+      const tasks = await store.getScheduledTasksForChannel('ch1');
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].id).toBe('task-1');
+    });
+
+    it('getEnabledScheduledTasks filters disabled tasks', async () => {
+      await store.insertScheduledTask(baseTask);
+      await store.insertScheduledTask({ ...baseTask, id: 'task-2', enabled: false });
+      const enabled = await store.getEnabledScheduledTasks();
+      expect(enabled).toHaveLength(1);
+      expect(enabled[0].id).toBe('task-1');
+    });
+
+    it('updateScheduledTaskEnabled toggles enabled flag', async () => {
+      await store.insertScheduledTask(baseTask);
+      await store.updateScheduledTaskEnabled('task-1', false);
+      const task = await store.getScheduledTask('task-1');
+      expect(task!.enabled).toBe(false);
+    });
+
+    it('updateScheduledTaskLastRun sets timestamps', async () => {
+      await store.insertScheduledTask(baseTask);
+      const now = new Date().toISOString();
+      const next = new Date(Date.now() + 3600_000).toISOString();
+      await store.updateScheduledTaskLastRun('task-1', now, next);
+      const task = await store.getScheduledTask('task-1');
+      expect(task!.lastRun).toBe(now);
+      expect(task!.nextRun).toBe(next);
+    });
+
+    it('deleteScheduledTask removes the task', async () => {
+      await store.insertScheduledTask(baseTask);
+      await store.deleteScheduledTask('task-1');
+      expect(await store.getScheduledTask('task-1')).toBeNull();
+    });
+
+    it('task with cronExpr and nextRun round-trips', async () => {
+      const cronTask = { ...baseTask, cronExpr: '0 * * * *', nextRun: '2025-01-01T01:00:00Z' };
+      await store.insertScheduledTask(cronTask);
+      const task = await store.getScheduledTask('task-1');
+      expect(task!.cronExpr).toBe('0 * * * *');
+      expect(task!.nextRun).toBe('2025-01-01T01:00:00Z');
+    });
+  });
+
+  // ---- Task History -------------------------------------------------------
+
+  describe('task history', () => {
+    it('insert and get history entry', async () => {
+      await store.insertTaskHistory({
+        taskId: 'task-1',
+        channelId: 'ch1',
+        prompt: 'do something',
+        timezone: 'UTC',
+        status: 'success',
+      });
+      const history = await store.getTaskHistory('ch1');
+      expect(history).toHaveLength(1);
+      expect(history[0].taskId).toBe('task-1');
+      expect(history[0].status).toBe('success');
+      expect(history[0].firedAt).toBeDefined();
+    });
+
+    it('error entry stores error message', async () => {
+      await store.insertTaskHistory({
+        taskId: 'task-1',
+        channelId: 'ch1',
+        prompt: 'fail',
+        timezone: 'UTC',
+        status: 'error',
+        error: 'something broke',
+      });
+      const history = await store.getTaskHistory('ch1');
+      expect(history[0].status).toBe('error');
+      expect(history[0].error).toBe('something broke');
+    });
+
+    it('getTaskHistory respects limit', async () => {
+      for (let i = 0; i < 5; i++) {
+        await store.insertTaskHistory({
+          taskId: `task-${i}`,
+          channelId: 'ch1',
+          prompt: `prompt-${i}`,
+          timezone: 'UTC',
+          status: 'success',
+        });
+      }
+      const history = await store.getTaskHistory('ch1', 3);
+      expect(history).toHaveLength(3);
+    });
+  });
+
+  // ---- Error handling -----------------------------------------------------
+
+  describe('error handling', () => {
+    it('operations on uninitialized store throw', async () => {
+      const uninit = new SqliteStateStore(path.join(tmpDir, 'never-init.db'));
+      await expect(uninit.getChannelSession('ch1')).rejects.toThrow(/not initialized/i);
+      await expect(uninit.setChannelPrefs('ch1', {})).rejects.toThrow(/not initialized/i);
+      await expect(uninit.getGlobalSetting('k')).rejects.toThrow(/not initialized/i);
+    });
+  });
+});

--- a/src/state/sqlite-store.ts
+++ b/src/state/sqlite-store.ts
@@ -341,14 +341,19 @@ export class SqliteStateStore implements StateStore {
   }
 
   async withTransaction<T>(fn: () => Promise<T>): Promise<T> {
+    // For SQLite, all store methods are synchronous under the hood (wrapped
+    // in async/Promise). We use BEGIN/COMMIT/ROLLBACK manually but guard
+    // against interleaving by executing fn() without yielding between
+    // BEGIN and COMMIT. Since better-sqlite3 operations are synchronous,
+    // the await only resolves an already-settled promise.
     const db = this.getDb();
-    db.exec('BEGIN');
+    db.exec('BEGIN IMMEDIATE');
     try {
       const result = await fn();
       db.exec('COMMIT');
       return result;
     } catch (err) {
-      db.exec('ROLLBACK');
+      try { db.exec('ROLLBACK'); } catch { /* already rolled back */ }
       throw err;
     }
   }

--- a/src/state/sqlite-store.ts
+++ b/src/state/sqlite-store.ts
@@ -1,0 +1,958 @@
+import Database from 'better-sqlite3';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+import { performance } from 'node:perf_hooks';
+import { createLogger } from '../logger.js';
+import type {
+  StateStore,
+  ChannelPrefs,
+  StoredPermissionRule,
+  WorkspaceOverride,
+  DynamicChannel,
+  AgentCallRecord,
+  ScheduledTask,
+  TaskHistoryEntry,
+} from './types.js';
+
+const log = createLogger('store');
+const SLOW_QUERY_MS = 50;
+
+export const DEFAULT_DB_PATH = path.join(os.homedir(), '.copilot-bridge', 'state.db');
+
+// ---------------------------------------------------------------------------
+// Standalone helpers
+// ---------------------------------------------------------------------------
+
+/** Classify SQLite error codes into severity buckets for logging. */
+function classifyDbError(err: unknown): 'busy' | 'corrupt' | 'full' | 'readonly' | 'other' {
+  const code = (err as any)?.code as string | undefined;
+  if (!code) return 'other';
+  if (code === 'SQLITE_BUSY' || code.startsWith('SQLITE_BUSY_')) return 'busy';
+  if (code === 'SQLITE_CORRUPT' || code.startsWith('SQLITE_CORRUPT_')) return 'corrupt';
+  if (code === 'SQLITE_FULL') return 'full';
+  if (code === 'SQLITE_READONLY' || code.startsWith('SQLITE_READONLY_')) return 'readonly';
+  return 'other';
+}
+
+function safeParseStringArray(raw: string): string[] | undefined {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return undefined;
+    return parsed.filter((v: unknown) => typeof v === 'string');
+  } catch { return undefined; }
+}
+
+function safeParseAllowPaths(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function mapDynamicChannelRow(row: any): DynamicChannel {
+  return {
+    channelId: row.channel_id,
+    platform: row.platform,
+    name: row.name,
+    bot: row.bot ?? undefined,
+    workingDirectory: row.working_directory,
+    agent: row.agent,
+    model: row.model ?? undefined,
+    triggerMode: row.trigger_mode as 'mention' | 'all' | undefined,
+    threadedReplies: row.threaded_replies != null ? !!row.threaded_replies : undefined,
+    verbose: row.verbose != null ? !!row.verbose : undefined,
+    isDM: !!row.is_dm,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapTaskRow(r: any): ScheduledTask {
+  return {
+    id: r.id,
+    channelId: r.channel_id,
+    botName: r.bot_name,
+    prompt: r.prompt,
+    cronExpr: r.cron_expr ?? undefined,
+    runAt: r.run_at ?? undefined,
+    timezone: r.timezone,
+    createdBy: r.created_by ?? undefined,
+    description: r.description ?? undefined,
+    enabled: !!r.enabled,
+    lastRun: r.last_run ?? undefined,
+    nextRun: r.next_run ?? undefined,
+    createdAt: r.created_at,
+  };
+}
+
+/** Migrate channel_prefs: drop NOT NULL on columns that should be nullable. */
+function migrateChannelPrefsNullable(db: Database.Database): void {
+  const cols = db.prepare("PRAGMA table_info('channel_prefs')").all() as any[];
+  const nullableTargets = new Set(['verbose', 'trigger_mode', 'threaded_replies', 'permission_mode']);
+  const needsMigration = cols.some(
+    (c: any) => nullableTargets.has(c.name) && c.notnull === 1
+  );
+  if (!needsMigration) return;
+
+  // Build dynamic column definitions preserving all existing columns
+  const columnDefs: string[] = [];
+  const selectExprs: string[] = [];
+
+  for (const c of cols) {
+    const name = c.name as string;
+    const parts: string[] = [`"${name}"`];
+    if (c.type) parts.push(c.type);
+    if (c.pk === 1) parts.push('PRIMARY KEY');
+    // Drop NOT NULL only for targeted columns; preserve for others
+    if (c.notnull === 1 && !nullableTargets.has(name)) parts.push('NOT NULL');
+    if (c.dflt_value !== null && c.dflt_value !== undefined) parts.push(`DEFAULT ${c.dflt_value}`);
+    columnDefs.push(parts.join(' '));
+
+    // Ensure updated_at is non-NULL during copy
+    if (name === 'updated_at') {
+      selectExprs.push("COALESCE(updated_at, datetime('now'))");
+    } else {
+      selectExprs.push(`"${name}"`);
+    }
+  }
+
+  // Capture existing indexes/triggers to recreate after rebuild
+  const schemaObjects = db.prepare(
+    "SELECT sql FROM sqlite_master WHERE tbl_name = 'channel_prefs' AND type IN ('index','trigger') AND sql IS NOT NULL"
+  ).all() as any[];
+
+  const migrate = db.transaction(() => {
+    db.exec(`DROP TABLE IF EXISTS channel_prefs_new`);
+    db.exec(`CREATE TABLE channel_prefs_new (${columnDefs.join(', ')})`);
+    db.exec(`
+      INSERT INTO channel_prefs_new SELECT ${selectExprs.join(', ')} FROM channel_prefs;
+      DROP TABLE channel_prefs;
+      ALTER TABLE channel_prefs_new RENAME TO channel_prefs;
+    `);
+    for (const obj of schemaObjects) {
+      if (obj.sql) db.exec(obj.sql);
+    }
+  });
+  migrate();
+}
+
+// ---------------------------------------------------------------------------
+// Observability helper — logs classified errors with method context
+// ---------------------------------------------------------------------------
+
+function logDbError(method: string, err: unknown): void {
+  const kind = classifyDbError(err);
+  if (kind === 'corrupt') log.error(`${method} CRITICAL - database may be corrupt:`, err);
+  else if (kind === 'full') log.error(`${method} CRITICAL - disk full:`, err);
+  else if (kind === 'busy') log.warn(`${method} - database busy (contention):`, err);
+  else if (kind === 'readonly') log.error(`${method} - database is read-only:`, err);
+  else log.error(`${method} failed:`, err);
+}
+
+// ---------------------------------------------------------------------------
+// SqliteStateStore
+// ---------------------------------------------------------------------------
+
+export class SqliteStateStore implements StateStore {
+  private db: Database.Database | null = null;
+  private readonly dbPath: string;
+
+  constructor(dbPath?: string) {
+    this.dbPath = dbPath ?? DEFAULT_DB_PATH;
+  }
+
+  // -- Private helpers ------------------------------------------------------
+
+  private getDb(): Database.Database {
+    if (!this.db) throw new Error('Store not initialized — call initialize() first');
+    return this.db;
+  }
+
+  // -- Lifecycle ------------------------------------------------------------
+
+  async initialize(): Promise<void> {
+    const dir = path.dirname(this.dbPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    this.db = new Database(this.dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS channel_sessions (
+        channel_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS channel_prefs (
+        channel_id TEXT PRIMARY KEY,
+        model TEXT,
+        agent TEXT,
+        verbose INTEGER,
+        trigger_mode TEXT,
+        threaded_replies INTEGER,
+        permission_mode TEXT,
+        reasoning_effort TEXT,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS permission_rules (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        scope TEXT NOT NULL DEFAULT 'global',
+        tool TEXT NOT NULL,
+        command_pattern TEXT NOT NULL DEFAULT '*',
+        action TEXT NOT NULL CHECK (action IN ('allow', 'deny')),
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_perm_scope ON permission_rules(scope);
+      CREATE INDEX IF NOT EXISTS idx_perm_tool ON permission_rules(tool);
+
+      CREATE TABLE IF NOT EXISTS workspace_overrides (
+        bot_name TEXT PRIMARY KEY,
+        working_directory TEXT NOT NULL,
+        allow_paths TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS settings (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS dynamic_channels (
+        channel_id TEXT PRIMARY KEY,
+        platform TEXT NOT NULL,
+        name TEXT NOT NULL DEFAULT '',
+        bot TEXT,
+        working_directory TEXT NOT NULL,
+        agent TEXT,
+        model TEXT,
+        trigger_mode TEXT,
+        threaded_replies INTEGER,
+        verbose INTEGER,
+        is_dm INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS agent_calls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        caller_bot TEXT NOT NULL,
+        target_bot TEXT NOT NULL,
+        target_agent TEXT,
+        message_summary TEXT,
+        response_summary TEXT,
+        duration_ms INTEGER,
+        success INTEGER NOT NULL DEFAULT 0,
+        error TEXT,
+        chain_id TEXT,
+        depth INTEGER DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_agent_calls_created ON agent_calls(created_at);
+      CREATE INDEX IF NOT EXISTS idx_agent_calls_chain ON agent_calls(chain_id);
+
+      CREATE TABLE IF NOT EXISTS scheduled_tasks (
+        id TEXT PRIMARY KEY,
+        channel_id TEXT NOT NULL,
+        bot_name TEXT NOT NULL,
+        prompt TEXT NOT NULL,
+        cron_expr TEXT,
+        run_at TEXT,
+        timezone TEXT NOT NULL DEFAULT 'UTC',
+        created_by TEXT,
+        description TEXT,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        last_run TEXT,
+        next_run TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_sched_channel ON scheduled_tasks(channel_id);
+      CREATE INDEX IF NOT EXISTS idx_sched_enabled ON scheduled_tasks(enabled);
+
+      CREATE TABLE IF NOT EXISTS scheduled_task_history (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        task_id TEXT NOT NULL,
+        channel_id TEXT NOT NULL,
+        prompt TEXT NOT NULL,
+        description TEXT,
+        timezone TEXT NOT NULL DEFAULT 'UTC',
+        status TEXT NOT NULL DEFAULT 'success',
+        fired_at TEXT NOT NULL DEFAULT (datetime('now')),
+        error TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_sched_hist_task ON scheduled_task_history(task_id);
+      CREATE INDEX IF NOT EXISTS idx_sched_hist_channel ON scheduled_task_history(channel_id);
+    `);
+
+    // Migration: ensure channel_prefs columns are nullable (fixes NOT NULL constraints from older schema)
+    migrateChannelPrefsNullable(this.db);
+
+    // Schema migrations for existing DBs
+    try { this.db.exec(`ALTER TABLE channel_prefs ADD COLUMN reasoning_effort TEXT`); } catch { /* Column already exists */ }
+    try { this.db.exec(`ALTER TABLE scheduled_task_history ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'`); } catch { /* Column already exists */ }
+    try { this.db.exec(`ALTER TABLE channel_prefs ADD COLUMN session_mode TEXT`); } catch { /* Column already exists */ }
+    try { this.db.exec(`ALTER TABLE channel_prefs ADD COLUMN disabled_skills TEXT`); } catch { /* Column already exists */ }
+    try { this.db.exec(`ALTER TABLE channel_prefs ADD COLUMN provider TEXT`); } catch { /* Column already exists */ }
+  }
+
+  async close(): Promise<void> {
+    try {
+      this.db?.close();
+    } catch (err) {
+      log.warn('Failed to close database cleanly:', err);
+    } finally {
+      this.db = null;
+    }
+  }
+
+  async ping(): Promise<boolean> {
+    try {
+      const db = this.getDb();
+      db.prepare('SELECT 1').get();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // -- Sessions -------------------------------------------------------------
+
+  async getChannelSession(channelId: string): Promise<string | null> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const row = db.prepare('SELECT session_id FROM channel_sessions WHERE channel_id = ?').get(channelId) as { session_id: string } | undefined;
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getChannelSession took ${elapsed.toFixed(0)}ms`);
+      return row?.session_id ?? null;
+    } catch (err) {
+      logDbError('getChannelSession', err);
+      throw err;
+    }
+  }
+
+  async setChannelSession(channelId: string, sessionId: string): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare(
+        'INSERT OR REPLACE INTO channel_sessions (channel_id, session_id, created_at) VALUES (?, ?, datetime(\'now\'))'
+      ).run(channelId, sessionId);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`setChannelSession took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('setChannelSession', err);
+      throw err;
+    }
+  }
+
+  async clearChannelSession(channelId: string): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare('DELETE FROM channel_sessions WHERE channel_id = ?').run(channelId);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`clearChannelSession took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('clearChannelSession', err);
+      throw err;
+    }
+  }
+
+  async getAllChannelSessions(): Promise<Array<{ channelId: string; sessionId: string }>> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const rows = db.prepare('SELECT channel_id, session_id FROM channel_sessions').all() as any[];
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getAllChannelSessions took ${elapsed.toFixed(0)}ms`);
+      return rows.map(r => ({ channelId: r.channel_id, sessionId: r.session_id }));
+    } catch (err) {
+      logDbError('getAllChannelSessions', err);
+      throw err;
+    }
+  }
+
+  // -- Preferences ----------------------------------------------------------
+
+  async getChannelPrefs(channelId: string): Promise<ChannelPrefs | null> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const row = db.prepare('SELECT * FROM channel_prefs WHERE channel_id = ?').get(channelId) as any;
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getChannelPrefs took ${elapsed.toFixed(0)}ms`);
+      if (!row) return null;
+      return {
+        model: row.model ?? undefined,
+        provider: row.provider ?? null,
+        agent: row.agent,
+        verbose: row.verbose != null ? !!row.verbose : undefined,
+        threadedReplies: row.threaded_replies != null ? !!row.threaded_replies : undefined,
+        permissionMode: row.permission_mode ?? undefined,
+        reasoningEffort: row.reasoning_effort ?? null,
+        sessionMode: row.session_mode ?? undefined,
+        disabledSkills: row.disabled_skills ? safeParseStringArray(row.disabled_skills) : undefined,
+      };
+    } catch (err) {
+      logDbError('getChannelPrefs', err);
+      throw err;
+    }
+  }
+
+  async setChannelPrefs(channelId: string, prefs: Partial<ChannelPrefs>): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+
+      const txn = db.transaction(() => {
+        // Ensure a row exists (upsert-safe — avoids TOCTOU race with async callers)
+        db.prepare(
+          `INSERT OR IGNORE INTO channel_prefs (channel_id) VALUES (?)`
+        ).run(channelId);
+
+        const updates: string[] = [];
+        const values: any[] = [];
+
+        if (prefs.model !== undefined) { updates.push('model = ?'); values.push(prefs.model); }
+        if (prefs.provider !== undefined) { updates.push('provider = ?'); values.push(prefs.provider); }
+        if (prefs.agent !== undefined) { updates.push('agent = ?'); values.push(prefs.agent); }
+        if (prefs.verbose !== undefined) { updates.push('verbose = ?'); values.push(prefs.verbose ? 1 : 0); }
+        if (prefs.threadedReplies !== undefined) { updates.push('threaded_replies = ?'); values.push(prefs.threadedReplies ? 1 : 0); }
+        if (prefs.permissionMode !== undefined) { updates.push('permission_mode = ?'); values.push(prefs.permissionMode); }
+        if (prefs.reasoningEffort !== undefined) { updates.push('reasoning_effort = ?'); values.push(prefs.reasoningEffort); }
+        if (prefs.sessionMode !== undefined) { updates.push('session_mode = ?'); values.push(prefs.sessionMode); }
+        if (prefs.disabledSkills !== undefined) { updates.push('disabled_skills = ?'); values.push(JSON.stringify(prefs.disabledSkills)); }
+
+        if (updates.length > 0) {
+          updates.push("updated_at = datetime('now')");
+          values.push(channelId);
+          db.prepare(`UPDATE channel_prefs SET ${updates.join(', ')} WHERE channel_id = ?`).run(...values);
+        }
+      });
+      txn();
+
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`setChannelPrefs took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('setChannelPrefs', err);
+      throw err;
+    }
+  }
+
+  // -- Permissions ----------------------------------------------------------
+
+  async getPermissionRules(scope: string, tool: string): Promise<StoredPermissionRule[]> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const rows = db.prepare(
+        'SELECT * FROM permission_rules WHERE (scope = ? OR scope = \'global\') AND tool = ? ORDER BY scope DESC, id DESC'
+      ).all(scope, tool) as any[];
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getPermissionRules took ${elapsed.toFixed(0)}ms`);
+      return rows.map(r => ({
+        id: r.id,
+        scope: r.scope,
+        tool: r.tool,
+        commandPattern: r.command_pattern,
+        action: r.action,
+        createdAt: r.created_at,
+      }));
+    } catch (err) {
+      logDbError('getPermissionRules', err);
+      throw err;
+    }
+  }
+
+  async addPermissionRule(scope: string, tool: string, commandPattern: string, action: 'allow' | 'deny'): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+
+      const txn = db.transaction(() => {
+        // Remove existing rule for same scope+tool+pattern before inserting
+        db.prepare(
+          'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
+        ).run(scope, tool, commandPattern);
+
+        db.prepare(
+          'INSERT INTO permission_rules (scope, tool, command_pattern, action) VALUES (?, ?, ?, ?)'
+        ).run(scope, tool, commandPattern, action);
+      });
+      txn();
+
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`addPermissionRule took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('addPermissionRule', err);
+      throw err;
+    }
+  }
+
+  async clearPermissionRules(scope: string): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare('DELETE FROM permission_rules WHERE scope = ?').run(scope);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`clearPermissionRules took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('clearPermissionRules', err);
+      throw err;
+    }
+  }
+
+  async removePermissionRule(scope: string, tool: string, commandPattern: string): Promise<boolean> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const result = db.prepare(
+        'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
+      ).run(scope, tool, commandPattern);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`removePermissionRule took ${elapsed.toFixed(0)}ms`);
+      return result.changes > 0;
+    } catch (err) {
+      logDbError('removePermissionRule', err);
+      throw err;
+    }
+  }
+
+  async listPermissionRulesForScope(scope: string): Promise<StoredPermissionRule[]> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const rows = db.prepare(
+        'SELECT * FROM permission_rules WHERE scope = ? ORDER BY tool, command_pattern'
+      ).all(scope) as any[];
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`listPermissionRulesForScope took ${elapsed.toFixed(0)}ms`);
+      return rows.map(r => ({
+        id: r.id,
+        scope: r.scope,
+        tool: r.tool,
+        commandPattern: r.command_pattern,
+        action: r.action,
+        createdAt: r.created_at,
+      }));
+    } catch (err) {
+      logDbError('listPermissionRulesForScope', err);
+      throw err;
+    }
+  }
+
+  async checkPermission(scope: string, tool: string, command: string): Promise<'allow' | 'deny' | null> {
+    const rules = await this.getPermissionRules(scope, tool);
+
+    for (const rule of rules) {
+      // Exact match or wildcard
+      if (rule.commandPattern === '*' || rule.commandPattern === command) {
+        return rule.action;
+      }
+    }
+
+    return null;
+  }
+
+  // -- Workspaces -----------------------------------------------------------
+
+  async getWorkspaceOverride(botName: string): Promise<WorkspaceOverride | null> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const row = db.prepare('SELECT * FROM workspace_overrides WHERE bot_name = ?').get(botName) as any;
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getWorkspaceOverride took ${elapsed.toFixed(0)}ms`);
+      if (!row) return null;
+      return {
+        botName: row.bot_name,
+        workingDirectory: row.working_directory,
+        allowPaths: safeParseAllowPaths(row.allow_paths),
+        createdAt: row.created_at,
+      };
+    } catch (err) {
+      logDbError('getWorkspaceOverride', err);
+      throw err;
+    }
+  }
+
+  async setWorkspaceOverride(botName: string, workingDirectory: string, allowPaths?: string[]): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare(
+        `INSERT INTO workspace_overrides (bot_name, working_directory, allow_paths, created_at)
+         VALUES (?, ?, ?, datetime('now'))
+         ON CONFLICT(bot_name) DO UPDATE SET
+           working_directory = excluded.working_directory,
+           allow_paths = excluded.allow_paths`
+      ).run(botName, workingDirectory, JSON.stringify(allowPaths ?? []));
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`setWorkspaceOverride took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('setWorkspaceOverride', err);
+      throw err;
+    }
+  }
+
+  async removeWorkspaceOverride(botName: string): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare('DELETE FROM workspace_overrides WHERE bot_name = ?').run(botName);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`removeWorkspaceOverride took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('removeWorkspaceOverride', err);
+      throw err;
+    }
+  }
+
+  async listWorkspaceOverrides(): Promise<WorkspaceOverride[]> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const rows = db.prepare('SELECT * FROM workspace_overrides').all() as any[];
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`listWorkspaceOverrides took ${elapsed.toFixed(0)}ms`);
+      return rows.map(row => ({
+        botName: row.bot_name,
+        workingDirectory: row.working_directory,
+        allowPaths: safeParseAllowPaths(row.allow_paths),
+        createdAt: row.created_at,
+      }));
+    } catch (err) {
+      logDbError('listWorkspaceOverrides', err);
+      throw err;
+    }
+  }
+
+  // -- Settings -------------------------------------------------------------
+
+  async getGlobalSetting(key: string): Promise<string | null> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getGlobalSetting took ${elapsed.toFixed(0)}ms`);
+      return row?.value ?? null;
+    } catch (err) {
+      logDbError('getGlobalSetting', err);
+      throw err;
+    }
+  }
+
+  async setGlobalSetting(key: string, value: string): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare(
+        `INSERT INTO settings (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+      ).run(key, value);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`setGlobalSetting took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('setGlobalSetting', err);
+      throw err;
+    }
+  }
+
+  // -- Dynamic Channels -----------------------------------------------------
+
+  async addDynamicChannel(channel: Omit<DynamicChannel, 'createdAt' | 'updatedAt'>): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare(
+        `INSERT INTO dynamic_channels (channel_id, platform, name, bot, working_directory, agent, model, trigger_mode, threaded_replies, verbose, is_dm)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(channel_id) DO UPDATE SET
+           platform = excluded.platform, name = excluded.name, bot = excluded.bot,
+           working_directory = excluded.working_directory, agent = excluded.agent,
+           model = excluded.model, trigger_mode = excluded.trigger_mode,
+           threaded_replies = excluded.threaded_replies, verbose = excluded.verbose,
+           is_dm = excluded.is_dm, updated_at = datetime('now')`
+      ).run(
+        channel.channelId,
+        channel.platform,
+        channel.name ?? '',
+        channel.bot ?? null,
+        channel.workingDirectory,
+        channel.agent ?? null,
+        channel.model ?? null,
+        channel.triggerMode ?? null,
+        channel.threadedReplies != null ? (channel.threadedReplies ? 1 : 0) : null,
+        channel.verbose != null ? (channel.verbose ? 1 : 0) : null,
+        channel.isDM ? 1 : 0,
+      );
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`addDynamicChannel took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('addDynamicChannel', err);
+      throw err;
+    }
+  }
+
+  async removeDynamicChannel(channelId: string): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare('DELETE FROM dynamic_channels WHERE channel_id = ?').run(channelId);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`removeDynamicChannel took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('removeDynamicChannel', err);
+      throw err;
+    }
+  }
+
+  async getDynamicChannel(channelId: string): Promise<DynamicChannel | null> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const row = db.prepare('SELECT * FROM dynamic_channels WHERE channel_id = ?').get(channelId) as any;
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getDynamicChannel took ${elapsed.toFixed(0)}ms`);
+      if (!row) return null;
+      return mapDynamicChannelRow(row);
+    } catch (err) {
+      logDbError('getDynamicChannel', err);
+      throw err;
+    }
+  }
+
+  async getDynamicChannels(): Promise<DynamicChannel[]> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const rows = db.prepare('SELECT * FROM dynamic_channels ORDER BY created_at').all() as any[];
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getDynamicChannels took ${elapsed.toFixed(0)}ms`);
+      return rows.map(mapDynamicChannelRow);
+    } catch (err) {
+      logDbError('getDynamicChannels', err);
+      throw err;
+    }
+  }
+
+  // -- Agent Calls ----------------------------------------------------------
+
+  async recordAgentCall(record: AgentCallRecord): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare(
+        `INSERT INTO agent_calls (caller_bot, target_bot, target_agent, message_summary, response_summary, duration_ms, success, error, chain_id, depth)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        record.callerBot,
+        record.targetBot,
+        record.targetAgent ?? null,
+        record.messageSummary ?? null,
+        record.responseSummary ?? null,
+        record.durationMs ?? null,
+        record.success ? 1 : 0,
+        record.error ?? null,
+        record.chainId ?? null,
+        record.depth ?? 0,
+      );
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`recordAgentCall took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('recordAgentCall', err);
+      throw err;
+    }
+  }
+
+  async getRecentAgentCalls(limit: number = 20): Promise<Array<AgentCallRecord & { id: number; createdAt: string }>> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const rows = db.prepare(
+        'SELECT * FROM agent_calls ORDER BY created_at DESC LIMIT ?'
+      ).all(limit) as any[];
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getRecentAgentCalls took ${elapsed.toFixed(0)}ms`);
+      return rows.map(r => ({
+        id: r.id,
+        callerBot: r.caller_bot,
+        targetBot: r.target_bot,
+        targetAgent: r.target_agent ?? undefined,
+        messageSummary: r.message_summary ?? undefined,
+        responseSummary: r.response_summary ?? undefined,
+        durationMs: r.duration_ms ?? undefined,
+        success: !!r.success,
+        error: r.error ?? undefined,
+        chainId: r.chain_id ?? undefined,
+        depth: r.depth ?? 0,
+        createdAt: r.created_at,
+      }));
+    } catch (err) {
+      logDbError('getRecentAgentCalls', err);
+      throw err;
+    }
+  }
+
+  // -- Scheduling -----------------------------------------------------------
+
+  async insertScheduledTask(task: Omit<ScheduledTask, 'createdAt' | 'lastRun' | 'nextRun'> & { nextRun?: string }): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare(`
+        INSERT INTO scheduled_tasks (id, channel_id, bot_name, prompt, cron_expr, run_at, timezone, created_by, description, enabled, next_run)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        task.id, task.channelId, task.botName, task.prompt,
+        task.cronExpr ?? null, task.runAt ?? null, task.timezone,
+        task.createdBy ?? null, task.description ?? null,
+        task.enabled ? 1 : 0, task.nextRun ?? null,
+      );
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`insertScheduledTask took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('insertScheduledTask', err);
+      throw err;
+    }
+  }
+
+  async getScheduledTask(id: string): Promise<ScheduledTask | null> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const row = db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as any;
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getScheduledTask took ${elapsed.toFixed(0)}ms`);
+      return row ? mapTaskRow(row) : null;
+    } catch (err) {
+      logDbError('getScheduledTask', err);
+      throw err;
+    }
+  }
+
+  async getScheduledTasksForChannel(channelId: string): Promise<ScheduledTask[]> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      // Show enabled tasks + paused recurring tasks (exclude disabled one-offs — they're finished)
+      const rows = db.prepare(
+        'SELECT * FROM scheduled_tasks WHERE channel_id = ? AND (enabled = 1 OR cron_expr IS NOT NULL) ORDER BY created_at DESC'
+      ).all(channelId) as any[];
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getScheduledTasksForChannel took ${elapsed.toFixed(0)}ms`);
+      return rows.map(mapTaskRow);
+    } catch (err) {
+      logDbError('getScheduledTasksForChannel', err);
+      throw err;
+    }
+  }
+
+  async getEnabledScheduledTasks(): Promise<ScheduledTask[]> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const rows = db.prepare('SELECT * FROM scheduled_tasks WHERE enabled = 1').all() as any[];
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getEnabledScheduledTasks took ${elapsed.toFixed(0)}ms`);
+      return rows.map(mapTaskRow);
+    } catch (err) {
+      logDbError('getEnabledScheduledTasks', err);
+      throw err;
+    }
+  }
+
+  async updateScheduledTaskEnabled(id: string, enabled: boolean): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare('UPDATE scheduled_tasks SET enabled = ? WHERE id = ?').run(enabled ? 1 : 0, id);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`updateScheduledTaskEnabled took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('updateScheduledTaskEnabled', err);
+      throw err;
+    }
+  }
+
+  async updateScheduledTaskLastRun(id: string, lastRun: string, nextRun?: string): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare('UPDATE scheduled_tasks SET last_run = ?, next_run = ? WHERE id = ?').run(lastRun, nextRun ?? null, id);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`updateScheduledTaskLastRun took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('updateScheduledTaskLastRun', err);
+      throw err;
+    }
+  }
+
+  async deleteScheduledTask(id: string): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare('DELETE FROM scheduled_tasks WHERE id = ?').run(id);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`deleteScheduledTask took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('deleteScheduledTask', err);
+      throw err;
+    }
+  }
+
+  async insertTaskHistory(entry: Omit<TaskHistoryEntry, 'id' | 'firedAt'>): Promise<void> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      db.prepare(`
+        INSERT INTO scheduled_task_history (task_id, channel_id, prompt, description, timezone, status, fired_at, error)
+        VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)
+      `).run(entry.taskId, entry.channelId, entry.prompt, entry.description ?? null, entry.timezone, entry.status, entry.error ?? null);
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`insertTaskHistory took ${elapsed.toFixed(0)}ms`);
+    } catch (err) {
+      logDbError('insertTaskHistory', err);
+      throw err;
+    }
+  }
+
+  async getTaskHistory(channelId: string, limit = 20): Promise<TaskHistoryEntry[]> {
+    try {
+      const start = performance.now();
+      const db = this.getDb();
+      const rows = db.prepare(
+        'SELECT * FROM scheduled_task_history WHERE channel_id = ? ORDER BY fired_at DESC LIMIT ?'
+      ).all(channelId, limit) as any[];
+      const elapsed = performance.now() - start;
+      if (elapsed > SLOW_QUERY_MS) log.warn(`getTaskHistory took ${elapsed.toFixed(0)}ms`);
+      return rows.map(r => ({
+        id: r.id,
+        taskId: r.task_id,
+        channelId: r.channel_id,
+        prompt: r.prompt,
+        description: r.description ?? undefined,
+        timezone: r.timezone ?? 'UTC',
+        status: r.status,
+        firedAt: r.fired_at,
+        error: r.error ?? undefined,
+      }));
+    } catch (err) {
+      logDbError('getTaskHistory', err);
+      throw err;
+    }
+  }
+}

--- a/src/state/sqlite-store.ts
+++ b/src/state/sqlite-store.ts
@@ -299,18 +299,31 @@ export class SqliteStateStore implements StateStore {
     migrateChannelPrefsNullable(this.db);
 
     // Schema migrations for existing DBs
-    try { this.db.exec(`ALTER TABLE channel_prefs ADD COLUMN reasoning_effort TEXT`); } catch { /* Column already exists */ }
-    try { this.db.exec(`ALTER TABLE scheduled_task_history ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'`); } catch { /* Column already exists */ }
-    try { this.db.exec(`ALTER TABLE channel_prefs ADD COLUMN session_mode TEXT`); } catch { /* Column already exists */ }
-    try { this.db.exec(`ALTER TABLE channel_prefs ADD COLUMN disabled_skills TEXT`); } catch { /* Column already exists */ }
-    try { this.db.exec(`ALTER TABLE channel_prefs ADD COLUMN provider TEXT`); } catch { /* Column already exists */ }
+    const tryMigration = (sql: string, label: string) => {
+      try {
+        this.db!.exec(sql);
+        log.debug(`Migration applied: ${label}`);
+      } catch (err: any) {
+        if (err?.message?.includes('duplicate column')) {
+          log.debug(`Migration skipped (already applied): ${label}`);
+        } else {
+          log.warn(`Migration failed for "${label}":`, err);
+        }
+      }
+    };
+    tryMigration(`ALTER TABLE channel_prefs ADD COLUMN reasoning_effort TEXT`, 'channel_prefs.reasoning_effort');
+    tryMigration(`ALTER TABLE scheduled_task_history ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'`, 'scheduled_task_history.timezone');
+    tryMigration(`ALTER TABLE channel_prefs ADD COLUMN session_mode TEXT`, 'channel_prefs.session_mode');
+    tryMigration(`ALTER TABLE channel_prefs ADD COLUMN disabled_skills TEXT`, 'channel_prefs.disabled_skills');
+    tryMigration(`ALTER TABLE channel_prefs ADD COLUMN provider TEXT`, 'channel_prefs.provider');
   }
 
   async close(): Promise<void> {
     try {
       this.db?.close();
+      log.info('SQLite database closed');
     } catch (err) {
-      log.warn('Failed to close database cleanly:', err);
+      log.warn('Failed to close SQLite database cleanly:', err);
     } finally {
       this.db = null;
     }
@@ -321,7 +334,8 @@ export class SqliteStateStore implements StateStore {
       const db = this.getDb();
       db.prepare('SELECT 1').get();
       return true;
-    } catch {
+    } catch (err) {
+      log.warn('ping() failed:', err);
       return false;
     }
   }

--- a/src/state/sqlite-store.ts
+++ b/src/state/sqlite-store.ts
@@ -340,6 +340,19 @@ export class SqliteStateStore implements StateStore {
     }
   }
 
+  async withTransaction<T>(fn: () => Promise<T>): Promise<T> {
+    const db = this.getDb();
+    db.exec('BEGIN');
+    try {
+      const result = await fn();
+      db.exec('COMMIT');
+      return result;
+    } catch (err) {
+      db.exec('ROLLBACK');
+      throw err;
+    }
+  }
+
   // -- Sessions -------------------------------------------------------------
 
   async getChannelSession(channelId: string): Promise<string | null> {

--- a/src/state/sqlite-store.ts
+++ b/src/state/sqlite-store.ts
@@ -341,21 +341,19 @@ export class SqliteStateStore implements StateStore {
   }
 
   async withTransaction<T>(fn: () => Promise<T>): Promise<T> {
-    // For SQLite, all store methods are synchronous under the hood (wrapped
-    // in async/Promise). We use BEGIN/COMMIT/ROLLBACK manually but guard
-    // against interleaving by executing fn() without yielding between
-    // BEGIN and COMMIT. Since better-sqlite3 operations are synchronous,
-    // the await only resolves an already-settled promise.
+    // All SqliteStateStore methods are synchronous (better-sqlite3), so
+    // fn() triggers DB writes synchronously even though it returns a Promise.
+    // We use db.transaction() to wrap those synchronous writes in
+    // BEGIN/COMMIT/ROLLBACK, then await fn()'s promise for the return value.
     const db = this.getDb();
-    db.exec('BEGIN IMMEDIATE');
-    try {
-      const result = await fn();
-      db.exec('COMMIT');
-      return result;
-    } catch (err) {
-      try { db.exec('ROLLBACK'); } catch { /* already rolled back */ }
-      throw err;
-    }
+    let fnPromise: Promise<T>;
+    const txn = db.transaction(() => {
+      // Calling fn() executes all synchronous DB operations immediately.
+      // The returned promise is already settled by the time fn() returns.
+      fnPromise = fn();
+    });
+    txn();
+    return fnPromise!;
   }
 
   // -- Sessions -------------------------------------------------------------

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  initStore,
+  getStore,
+  closeDb,
+  getChannelSession,
+  setChannelSession,
+  getChannelPrefs,
+  setChannelPrefs,
+  checkPermission,
+  getGlobalSetting,
+  setGlobalSetting,
+} from './store.js';
+import type {
+  StateStore,
+  ChannelPrefs,
+  StoredPermissionRule,
+  WorkspaceOverride,
+  DynamicChannel,
+  AgentCallRecord,
+  ScheduledTask,
+  TaskHistoryEntry,
+} from './store.js';
+
+// ---------------------------------------------------------------------------
+// Helper: full mock StateStore backed by vi.fn() spies
+// ---------------------------------------------------------------------------
+
+function createMockStore(): StateStore {
+  return {
+    initialize: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    close: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    ping: vi.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    getChannelSession: vi.fn().mockResolvedValue(null),
+    setChannelSession: vi.fn().mockResolvedValue(undefined),
+    clearChannelSession: vi.fn().mockResolvedValue(undefined),
+    getAllChannelSessions: vi.fn().mockResolvedValue([]),
+    getChannelPrefs: vi.fn().mockResolvedValue(null),
+    setChannelPrefs: vi.fn().mockResolvedValue(undefined),
+    getPermissionRules: vi.fn().mockResolvedValue([]),
+    addPermissionRule: vi.fn().mockResolvedValue(undefined),
+    clearPermissionRules: vi.fn().mockResolvedValue(undefined),
+    removePermissionRule: vi.fn().mockResolvedValue(false),
+    listPermissionRulesForScope: vi.fn().mockResolvedValue([]),
+    checkPermission: vi.fn().mockResolvedValue(null),
+    getWorkspaceOverride: vi.fn().mockResolvedValue(null),
+    setWorkspaceOverride: vi.fn().mockResolvedValue(undefined),
+    removeWorkspaceOverride: vi.fn().mockResolvedValue(undefined),
+    listWorkspaceOverrides: vi.fn().mockResolvedValue([]),
+    getGlobalSetting: vi.fn().mockResolvedValue(null),
+    setGlobalSetting: vi.fn().mockResolvedValue(undefined),
+    addDynamicChannel: vi.fn().mockResolvedValue(undefined),
+    removeDynamicChannel: vi.fn().mockResolvedValue(undefined),
+    getDynamicChannel: vi.fn().mockResolvedValue(null),
+    getDynamicChannels: vi.fn().mockResolvedValue([]),
+    recordAgentCall: vi.fn().mockResolvedValue(undefined),
+    getRecentAgentCalls: vi.fn().mockResolvedValue([]),
+    insertScheduledTask: vi.fn().mockResolvedValue(undefined),
+    getScheduledTask: vi.fn().mockResolvedValue(null),
+    getScheduledTasksForChannel: vi.fn().mockResolvedValue([]),
+    getEnabledScheduledTasks: vi.fn().mockResolvedValue([]),
+    updateScheduledTaskEnabled: vi.fn().mockResolvedValue(undefined),
+    updateScheduledTaskLastRun: vi.fn().mockResolvedValue(undefined),
+    deleteScheduledTask: vi.fn().mockResolvedValue(undefined),
+    insertTaskHistory: vi.fn().mockResolvedValue(undefined),
+    getTaskHistory: vi.fn().mockResolvedValue([]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('store facade', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'store-facade-'));
+  });
+
+  afterEach(async () => {
+    await closeDb();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ---- initStore lifecycle ------------------------------------------------
+
+  describe('initStore lifecycle', () => {
+    it('creates a working store with custom dbPath', async () => {
+      await initStore(undefined, path.join(tmpDir, 'test.db'));
+      const s = getStore();
+      expect(s).toBeDefined();
+      expect(await s.ping()).toBe(true);
+    });
+
+    it('accepts a custom StateStore implementation', async () => {
+      const mock = createMockStore();
+      await initStore(mock);
+      expect(getStore()).toBe(mock);
+      expect(mock.initialize).toHaveBeenCalledOnce();
+    });
+
+    it('accepts a custom dbPath (ignored when customStore provided)', async () => {
+      const mock = createMockStore();
+      await initStore(mock, '/should/be/ignored');
+      expect(getStore()).toBe(mock);
+    });
+
+    it('double-call closes previous store before re-init', async () => {
+      const first = createMockStore();
+      const second = createMockStore();
+      await initStore(first);
+      await initStore(second);
+      expect(first.close).toHaveBeenCalledOnce();
+      expect(second.initialize).toHaveBeenCalledOnce();
+      expect(getStore()).toBe(second);
+    });
+
+    it('getStore returns the same instance after init', async () => {
+      await initStore(undefined, path.join(tmpDir, 'test.db'));
+      const s1 = getStore();
+      const s2 = getStore();
+      expect(s1).toBe(s2);
+    });
+  });
+
+  // ---- closeDb lifecycle --------------------------------------------------
+
+  describe('closeDb lifecycle', () => {
+    it('closes the active store', async () => {
+      const mock = createMockStore();
+      await initStore(mock);
+      await closeDb();
+      expect(mock.close).toHaveBeenCalledOnce();
+    });
+
+    it('double-close is a no-op (no error)', async () => {
+      const mock = createMockStore();
+      await initStore(mock);
+      await closeDb();
+      await closeDb(); // second call should not throw
+      expect(mock.close).toHaveBeenCalledOnce();
+    });
+
+    it('after close, store functions auto-re-init', async () => {
+      await initStore(undefined, path.join(tmpDir, 'test.db'));
+      await closeDb();
+      // Calling getStore() triggers the auto-init fallback
+      const s = getStore();
+      expect(s).toBeDefined();
+    });
+  });
+
+  // ---- Facade delegation --------------------------------------------------
+
+  describe('facade delegation', () => {
+    beforeEach(async () => {
+      await initStore(undefined, path.join(tmpDir, 'test.db'));
+    });
+
+    it('setChannelSession / getChannelSession round-trips', async () => {
+      await setChannelSession('ch1', 'sess-abc');
+      expect(await getChannelSession('ch1')).toBe('sess-abc');
+    });
+
+    it('getChannelSession returns null for unknown channel', async () => {
+      expect(await getChannelSession('unknown')).toBeNull();
+    });
+
+    it('setChannelPrefs / getChannelPrefs round-trips', async () => {
+      await setChannelPrefs('ch1', { model: 'gpt-4', verbose: true });
+      const prefs = await getChannelPrefs('ch1');
+      expect(prefs).toBeDefined();
+      expect(prefs!.model).toBe('gpt-4');
+      expect(prefs!.verbose).toBe(true);
+    });
+
+    it('checkPermission returns null when no rules exist', async () => {
+      expect(await checkPermission('global', 'bash', 'ls')).toBeNull();
+    });
+
+    it('setGlobalSetting / getGlobalSetting round-trips', async () => {
+      await setGlobalSetting('theme', 'dark');
+      expect(await getGlobalSetting('theme')).toBe('dark');
+    });
+
+    it('getGlobalSetting returns null for unknown key', async () => {
+      expect(await getGlobalSetting('nonexistent')).toBeNull();
+    });
+  });
+
+  // ---- Type re-exports ----------------------------------------------------
+
+  describe('type re-exports', () => {
+    it('exports all shared types from store module', () => {
+      // These are compile-time checks — if the imports above resolve,
+      // the re-exports work. Runtime assertion as a guard:
+      const check: Record<string, unknown> = {
+        StateStore: undefined as unknown as StateStore,
+        ChannelPrefs: undefined as unknown as ChannelPrefs,
+        StoredPermissionRule: undefined as unknown as StoredPermissionRule,
+        WorkspaceOverride: undefined as unknown as WorkspaceOverride,
+        DynamicChannel: undefined as unknown as DynamicChannel,
+        AgentCallRecord: undefined as unknown as AgentCallRecord,
+        ScheduledTask: undefined as unknown as ScheduledTask,
+        TaskHistoryEntry: undefined as unknown as TaskHistoryEntry,
+      };
+      expect(Object.keys(check)).toHaveLength(8);
+    });
+  });
+});

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -34,6 +34,7 @@ function createMockStore(): StateStore {
     initialize: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     close: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     ping: vi.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    withTransaction: vi.fn().mockImplementation(async (fn: () => Promise<unknown>) => fn()),
     getChannelSession: vi.fn().mockResolvedValue(null),
     setChannelSession: vi.fn().mockResolvedValue(undefined),
     clearChannelSession: vi.fn().mockResolvedValue(undefined),

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -83,6 +83,9 @@ export function getStore(): StateStore {
 // ---------------------------------------------------------------------------
 
 // -- Sessions ---------------------------------------------------------------
+export async function withTransaction<T>(fn: () => Promise<T>): Promise<T> {
+  return store().withTransaction(fn);
+}
 export async function getChannelSession(channelId: string) {
   return store().getChannelSession(channelId);
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,1183 +1,202 @@
-import Database from 'better-sqlite3';
-import path from 'node:path';
-import os from 'node:os';
-import fs from 'node:fs';
-import { performance } from 'node:perf_hooks';
+/**
+ * State store facade — delegates every call to the active {@link StateStore}
+ * instance. Callers import from this module unchanged; the backing
+ * implementation is swapped via {@link initStore}.
+ *
+ * Default backend: {@link SqliteStateStore} (built-in, uses better-sqlite3).
+ * Custom backends are loaded at startup via the `database.module` config key.
+ */
+
 import { createLogger } from '../logger.js';
+import { SqliteStateStore } from './sqlite-store.js';
+import type { StateStore } from './types.js';
+
+// Re-export shared data types so existing callers keep working
+export type {
+  StateStore,
+  ChannelPrefs,
+  StoredPermissionRule,
+  WorkspaceOverride,
+  DynamicChannel,
+  AgentCallRecord,
+  ScheduledTask,
+  TaskHistoryEntry,
+} from './types.js';
 
 const log = createLogger('store');
-const DB_PATH = path.join(os.homedir(), '.copilot-bridge', 'state.db');
-const SLOW_QUERY_MS = 50;
 
-/** Classify SQLite error codes into severity buckets for logging. */
-function classifyDbError(err: unknown): 'busy' | 'corrupt' | 'full' | 'readonly' | 'other' {
-  const code = (err as any)?.code as string | undefined;
-  if (!code) return 'other';
-  if (code === 'SQLITE_BUSY' || code.startsWith('SQLITE_BUSY_')) return 'busy';
-  if (code === 'SQLITE_CORRUPT' || code.startsWith('SQLITE_CORRUPT_')) return 'corrupt';
-  if (code === 'SQLITE_FULL') return 'full';
-  if (code === 'SQLITE_READONLY' || code.startsWith('SQLITE_READONLY_')) return 'readonly';
-  return 'other';
-}
+// ---------------------------------------------------------------------------
+// Active store instance
+// ---------------------------------------------------------------------------
 
-function safeParseStringArray(raw: string): string[] | undefined {
-  try {
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return undefined;
-    return parsed.filter((v: unknown) => typeof v === 'string');
-  } catch { return undefined; }
-}
+let _store: StateStore | null = null;
 
-let _db: Database.Database | null = null;
-
-/** Migrate channel_prefs: drop NOT NULL on columns that should be nullable. */
-function migrateChannelPrefsNullable(db: Database.Database): void {
-  const cols = db.prepare("PRAGMA table_info('channel_prefs')").all() as any[];
-  const nullableTargets = new Set(['verbose', 'trigger_mode', 'threaded_replies', 'permission_mode']);
-  const needsMigration = cols.some(
-    (c: any) => nullableTargets.has(c.name) && c.notnull === 1
-  );
-  if (!needsMigration) return;
-
-  // Build dynamic column definitions preserving all existing columns
-  const columnDefs: string[] = [];
-  const selectExprs: string[] = [];
-
-  for (const c of cols) {
-    const name = c.name as string;
-    const parts: string[] = [`"${name}"`];
-    if (c.type) parts.push(c.type);
-    if (c.pk === 1) parts.push('PRIMARY KEY');
-    // Drop NOT NULL only for targeted columns; preserve for others
-    if (c.notnull === 1 && !nullableTargets.has(name)) parts.push('NOT NULL');
-    if (c.dflt_value !== null && c.dflt_value !== undefined) parts.push(`DEFAULT ${c.dflt_value}`);
-    columnDefs.push(parts.join(' '));
-
-    // Ensure updated_at is non-NULL during copy
-    if (name === 'updated_at') {
-      selectExprs.push("COALESCE(updated_at, datetime('now'))");
-    } else {
-      selectExprs.push(`"${name}"`);
-    }
+function store(): StateStore {
+  if (!_store) {
+    // Auto-initialize with default SQLite backend for backward compatibility
+    // (tests and code that call store functions before explicit initStore)
+    log.warn('Store accessed before initStore() — auto-initializing with defaults');
+    const sqlite = new SqliteStateStore();
+    // Synchronous field assignment; initialize() will be called on first real use
+    _store = sqlite;
+    // Fire-and-forget init — better-sqlite3 is synchronous so this resolves immediately
+    void sqlite.initialize();
   }
-
-  // Capture existing indexes/triggers to recreate after rebuild
-  const schemaObjects = db.prepare(
-    "SELECT sql FROM sqlite_master WHERE tbl_name = 'channel_prefs' AND type IN ('index','trigger') AND sql IS NOT NULL"
-  ).all() as any[];
-
-  const migrate = db.transaction(() => {
-    db.exec(`DROP TABLE IF EXISTS channel_prefs_new`);
-    db.exec(`CREATE TABLE channel_prefs_new (${columnDefs.join(', ')})`);
-    db.exec(`
-      INSERT INTO channel_prefs_new SELECT ${selectExprs.join(', ')} FROM channel_prefs;
-      DROP TABLE channel_prefs;
-      ALTER TABLE channel_prefs_new RENAME TO channel_prefs;
-    `);
-    for (const obj of schemaObjects) {
-      if (obj.sql) db.exec(obj.sql);
-    }
-  });
-  migrate();
-}
-
-function getDb(): Database.Database {
-  if (_db) return _db;
-
-  const dir = path.dirname(DB_PATH);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-
-  _db = new Database(DB_PATH);
-  _db.pragma('journal_mode = WAL');
-  _db.pragma('foreign_keys = ON');
-
-  // Create tables
-  _db.exec(`
-    CREATE TABLE IF NOT EXISTS channel_sessions (
-      channel_id TEXT PRIMARY KEY,
-      session_id TEXT NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE TABLE IF NOT EXISTS channel_prefs (
-      channel_id TEXT PRIMARY KEY,
-      model TEXT,
-      agent TEXT,
-      verbose INTEGER,
-      trigger_mode TEXT,
-      threaded_replies INTEGER,
-      permission_mode TEXT,
-      reasoning_effort TEXT,
-      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE TABLE IF NOT EXISTS permission_rules (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      scope TEXT NOT NULL DEFAULT 'global',
-      tool TEXT NOT NULL,
-      command_pattern TEXT NOT NULL DEFAULT '*',
-      action TEXT NOT NULL CHECK (action IN ('allow', 'deny')),
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_perm_scope ON permission_rules(scope);
-    CREATE INDEX IF NOT EXISTS idx_perm_tool ON permission_rules(tool);
-
-    CREATE TABLE IF NOT EXISTS workspace_overrides (
-      bot_name TEXT PRIMARY KEY,
-      working_directory TEXT NOT NULL,
-      allow_paths TEXT NOT NULL DEFAULT '[]',
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE TABLE IF NOT EXISTS settings (
-      key TEXT PRIMARY KEY,
-      value TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS dynamic_channels (
-      channel_id TEXT PRIMARY KEY,
-      platform TEXT NOT NULL,
-      name TEXT NOT NULL DEFAULT '',
-      bot TEXT,
-      working_directory TEXT NOT NULL,
-      agent TEXT,
-      model TEXT,
-      trigger_mode TEXT,
-      threaded_replies INTEGER,
-      verbose INTEGER,
-      is_dm INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE TABLE IF NOT EXISTS agent_calls (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      caller_bot TEXT NOT NULL,
-      target_bot TEXT NOT NULL,
-      target_agent TEXT,
-      message_summary TEXT,
-      response_summary TEXT,
-      duration_ms INTEGER,
-      success INTEGER NOT NULL DEFAULT 0,
-      error TEXT,
-      chain_id TEXT,
-      depth INTEGER DEFAULT 0,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_agent_calls_created ON agent_calls(created_at);
-    CREATE INDEX IF NOT EXISTS idx_agent_calls_chain ON agent_calls(chain_id);
-
-    CREATE TABLE IF NOT EXISTS scheduled_tasks (
-      id TEXT PRIMARY KEY,
-      channel_id TEXT NOT NULL,
-      bot_name TEXT NOT NULL,
-      prompt TEXT NOT NULL,
-      cron_expr TEXT,
-      run_at TEXT,
-      timezone TEXT NOT NULL DEFAULT 'UTC',
-      created_by TEXT,
-      description TEXT,
-      enabled INTEGER NOT NULL DEFAULT 1,
-      last_run TEXT,
-      next_run TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_sched_channel ON scheduled_tasks(channel_id);
-    CREATE INDEX IF NOT EXISTS idx_sched_enabled ON scheduled_tasks(enabled);
-
-    CREATE TABLE IF NOT EXISTS scheduled_task_history (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      task_id TEXT NOT NULL,
-      channel_id TEXT NOT NULL,
-      prompt TEXT NOT NULL,
-      description TEXT,
-      timezone TEXT NOT NULL DEFAULT 'UTC',
-      status TEXT NOT NULL DEFAULT 'success',
-      fired_at TEXT NOT NULL DEFAULT (datetime('now')),
-      error TEXT
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_sched_hist_task ON scheduled_task_history(task_id);
-    CREATE INDEX IF NOT EXISTS idx_sched_hist_channel ON scheduled_task_history(channel_id);
-  `);
-
-  // Migration: ensure channel_prefs columns are nullable (fixes NOT NULL constraints from older schema)
-  migrateChannelPrefsNullable(_db);
-
-  // Schema migrations for existing DBs
-  try {
-    _db.exec(`ALTER TABLE channel_prefs ADD COLUMN reasoning_effort TEXT`);
-  } catch {
-    // Column already exists
-  }
-  try {
-    _db.exec(`ALTER TABLE scheduled_task_history ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'`);
-  } catch {
-    // Column already exists
-  }
-  try {
-    _db.exec(`ALTER TABLE channel_prefs ADD COLUMN session_mode TEXT`);
-  } catch {
-    // Column already exists
-  }
-  try {
-    _db.exec(`ALTER TABLE channel_prefs ADD COLUMN disabled_skills TEXT`);
-  } catch {
-    // Column already exists
-  }
-  try {
-    _db.exec(`ALTER TABLE channel_prefs ADD COLUMN provider TEXT`);
-  } catch {
-    // Column already exists
-  }
-
-  return _db;
-}
-
-// --- Channel Sessions ---
-
-export async function getChannelSession(channelId: string): Promise<string | null> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const row = db.prepare('SELECT session_id FROM channel_sessions WHERE channel_id = ?').get(channelId) as { session_id: string } | undefined;
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getChannelSession took ${elapsed.toFixed(0)}ms`);
-    return row?.session_id ?? null;
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getChannelSession CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getChannelSession CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getChannelSession - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getChannelSession - database is read-only:', err);
-    else log.error('getChannelSession failed:', err);
-    throw err;
-  }
-}
-
-export async function setChannelSession(channelId: string, sessionId: string): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare(
-      'INSERT OR REPLACE INTO channel_sessions (channel_id, session_id, created_at) VALUES (?, ?, datetime(\'now\'))'
-    ).run(channelId, sessionId);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`setChannelSession took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('setChannelSession CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('setChannelSession CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('setChannelSession - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('setChannelSession - database is read-only:', err);
-    else log.error('setChannelSession failed:', err);
-    throw err;
-  }
-}
-
-export async function clearChannelSession(channelId: string): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare('DELETE FROM channel_sessions WHERE channel_id = ?').run(channelId);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`clearChannelSession took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('clearChannelSession CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('clearChannelSession CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('clearChannelSession - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('clearChannelSession - database is read-only:', err);
-    else log.error('clearChannelSession failed:', err);
-    throw err;
-  }
-}
-
-export async function getAllChannelSessions(): Promise<Array<{ channelId: string; sessionId: string }>> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const rows = db.prepare('SELECT channel_id, session_id FROM channel_sessions').all() as any[];
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getAllChannelSessions took ${elapsed.toFixed(0)}ms`);
-    return rows.map(r => ({ channelId: r.channel_id, sessionId: r.session_id }));
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getAllChannelSessions CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getAllChannelSessions CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getAllChannelSessions - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getAllChannelSessions - database is read-only:', err);
-    else log.error('getAllChannelSessions failed:', err);
-    throw err;
-  }
-}
-
-// --- Channel Preferences ---
-
-export interface ChannelPrefs {
-  model?: string;
-  provider?: string | null;
-  agent?: string | null;
-  verbose?: boolean;
-
-  threadedReplies?: boolean;
-  permissionMode?: string;
-  reasoningEffort?: string | null;
-  sessionMode?: string;
-  disabledSkills?: string[];
-}
-
-export async function getChannelPrefs(channelId: string): Promise<ChannelPrefs | null> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const row = db.prepare('SELECT * FROM channel_prefs WHERE channel_id = ?').get(channelId) as any;
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getChannelPrefs took ${elapsed.toFixed(0)}ms`);
-    if (!row) return null;
-    return {
-      model: row.model ?? undefined,
-      provider: row.provider ?? null,
-      agent: row.agent,
-      verbose: row.verbose != null ? !!row.verbose : undefined,
-
-      threadedReplies: row.threaded_replies != null ? !!row.threaded_replies : undefined,
-      permissionMode: row.permission_mode ?? undefined,
-      reasoningEffort: row.reasoning_effort ?? null,
-      sessionMode: row.session_mode ?? undefined,
-      disabledSkills: row.disabled_skills ? safeParseStringArray(row.disabled_skills) : undefined,
-    };
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getChannelPrefs CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getChannelPrefs CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getChannelPrefs - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getChannelPrefs - database is read-only:', err);
-    else log.error('getChannelPrefs failed:', err);
-    throw err;
-  }
-}
-
-export async function setChannelPrefs(channelId: string, prefs: Partial<ChannelPrefs>): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-
-    const txn = db.transaction(() => {
-      // Ensure a row exists (upsert-safe — avoids TOCTOU race with async callers)
-      db.prepare(
-        `INSERT OR IGNORE INTO channel_prefs (channel_id) VALUES (?)`
-      ).run(channelId);
-
-      const updates: string[] = [];
-      const values: any[] = [];
-
-      if (prefs.model !== undefined) { updates.push('model = ?'); values.push(prefs.model); }
-      if (prefs.provider !== undefined) { updates.push('provider = ?'); values.push(prefs.provider); }
-      if (prefs.agent !== undefined) { updates.push('agent = ?'); values.push(prefs.agent); }
-      if (prefs.verbose !== undefined) { updates.push('verbose = ?'); values.push(prefs.verbose ? 1 : 0); }
-
-      if (prefs.threadedReplies !== undefined) { updates.push('threaded_replies = ?'); values.push(prefs.threadedReplies ? 1 : 0); }
-      if (prefs.permissionMode !== undefined) { updates.push('permission_mode = ?'); values.push(prefs.permissionMode); }
-      if (prefs.reasoningEffort !== undefined) { updates.push('reasoning_effort = ?'); values.push(prefs.reasoningEffort); }
-      if (prefs.sessionMode !== undefined) { updates.push('session_mode = ?'); values.push(prefs.sessionMode); }
-      if (prefs.disabledSkills !== undefined) { updates.push('disabled_skills = ?'); values.push(JSON.stringify(prefs.disabledSkills)); }
-
-      if (updates.length > 0) {
-        updates.push("updated_at = datetime('now')");
-        values.push(channelId);
-        db.prepare(`UPDATE channel_prefs SET ${updates.join(', ')} WHERE channel_id = ?`).run(...values);
-      }
-    });
-    txn();
-
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`setChannelPrefs took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('setChannelPrefs CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('setChannelPrefs CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('setChannelPrefs - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('setChannelPrefs - database is read-only:', err);
-    else log.error('setChannelPrefs failed:', err);
-    throw err;
-  }
-}
-
-// --- Permission Rules ---
-
-export interface StoredPermissionRule {
-  id: number;
-  scope: string;
-  tool: string;
-  commandPattern: string;
-  action: 'allow' | 'deny';
-  createdAt: string;
-}
-
-export async function getPermissionRules(scope: string, tool: string): Promise<StoredPermissionRule[]> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const rows = db.prepare(
-      'SELECT * FROM permission_rules WHERE (scope = ? OR scope = \'global\') AND tool = ? ORDER BY scope DESC, id DESC'
-    ).all(scope, tool) as any[];
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getPermissionRules took ${elapsed.toFixed(0)}ms`);
-    return rows.map(r => ({
-      id: r.id,
-      scope: r.scope,
-      tool: r.tool,
-      commandPattern: r.command_pattern,
-      action: r.action,
-      createdAt: r.created_at,
-    }));
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getPermissionRules CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getPermissionRules CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getPermissionRules - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getPermissionRules - database is read-only:', err);
-    else log.error('getPermissionRules failed:', err);
-    throw err;
-  }
-}
-
-export async function addPermissionRule(scope: string, tool: string, commandPattern: string, action: 'allow' | 'deny'): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-
-    const txn = db.transaction(() => {
-      // Remove existing rule for same scope+tool+pattern before inserting
-      db.prepare(
-        'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
-      ).run(scope, tool, commandPattern);
-
-      db.prepare(
-        'INSERT INTO permission_rules (scope, tool, command_pattern, action) VALUES (?, ?, ?, ?)'
-      ).run(scope, tool, commandPattern, action);
-    });
-    txn();
-
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`addPermissionRule took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('addPermissionRule CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('addPermissionRule CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('addPermissionRule - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('addPermissionRule - database is read-only:', err);
-    else log.error('addPermissionRule failed:', err);
-    throw err;
-  }
-}
-
-export async function clearPermissionRules(scope: string): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare('DELETE FROM permission_rules WHERE scope = ?').run(scope);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`clearPermissionRules took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('clearPermissionRules CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('clearPermissionRules CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('clearPermissionRules - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('clearPermissionRules - database is read-only:', err);
-    else log.error('clearPermissionRules failed:', err);
-    throw err;
-  }
-}
-
-/** Remove a specific permission rule by scope + tool + command_pattern. */
-export async function removePermissionRule(scope: string, tool: string, commandPattern: string): Promise<boolean> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const result = db.prepare(
-      'DELETE FROM permission_rules WHERE scope = ? AND tool = ? AND command_pattern = ?'
-    ).run(scope, tool, commandPattern);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`removePermissionRule took ${elapsed.toFixed(0)}ms`);
-    return result.changes > 0;
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('removePermissionRule CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('removePermissionRule CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('removePermissionRule - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('removePermissionRule - database is read-only:', err);
-    else log.error('removePermissionRule failed:', err);
-    throw err;
-  }
-}
-
-/** List all permission rules for a scope. */
-export async function listPermissionRulesForScope(scope: string): Promise<StoredPermissionRule[]> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const rows = db.prepare(
-      'SELECT * FROM permission_rules WHERE scope = ? ORDER BY tool, command_pattern'
-    ).all(scope) as any[];
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`listPermissionRulesForScope took ${elapsed.toFixed(0)}ms`);
-    return rows.map(r => ({
-      id: r.id,
-      scope: r.scope,
-      tool: r.tool,
-      commandPattern: r.command_pattern,
-      action: r.action,
-      createdAt: r.created_at,
-    }));
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('listPermissionRulesForScope CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('listPermissionRulesForScope CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('listPermissionRulesForScope - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('listPermissionRulesForScope - database is read-only:', err);
-    else log.error('listPermissionRulesForScope failed:', err);
-    throw err;
-  }
+  return _store;
 }
 
 /**
- * Check if a tool+command is allowed by existing rules.
- * Returns 'allow', 'deny', or null (no matching rule — need to ask).
+ * Initialize the state store. Call once at startup before any other store
+ * function.
+ *
+ * @param customStore  An already-constructed {@link StateStore} to use instead
+ *                     of the built-in SQLite backend. Useful for tests and
+ *                     custom database plugins.
+ * @param dbPath       Path for the default SQLite backend (ignored when
+ *                     `customStore` is provided).
  */
-export async function checkPermission(scope: string, tool: string, command: string): Promise<'allow' | 'deny' | null> {
-  const rules = await getPermissionRules(scope, tool);
-
-  for (const rule of rules) {
-    // Exact match or wildcard
-    if (rule.commandPattern === '*' || rule.commandPattern === command) {
-      return rule.action;
-    }
+export async function initStore(customStore?: StateStore, dbPath?: string): Promise<void> {
+  if (_store) {
+    log.warn('initStore called when store already initialized — closing previous instance');
+    await closeDb();
   }
-
-  return null;
+  _store = customStore ?? new SqliteStateStore(dbPath);
+  await _store.initialize();
+  log.info('State store initialized');
 }
 
-// --- Workspace Overrides ---
-
-export interface WorkspaceOverride {
-  botName: string;
-  workingDirectory: string;
-  allowPaths: string[];
-  createdAt: string;
+/** Return the active store instance (for advanced use / testing). */
+export function getStore(): StateStore {
+  return store();
 }
 
-function safeParseAllowPaths(raw: string): string[] {
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
+// ---------------------------------------------------------------------------
+// Delegating facade — every function forwards to the active store
+// ---------------------------------------------------------------------------
+
+// -- Sessions ---------------------------------------------------------------
+export async function getChannelSession(channelId: string) {
+  return store().getChannelSession(channelId);
+}
+export async function setChannelSession(channelId: string, sessionId: string) {
+  return store().setChannelSession(channelId, sessionId);
+}
+export async function clearChannelSession(channelId: string) {
+  return store().clearChannelSession(channelId);
+}
+export async function getAllChannelSessions() {
+  return store().getAllChannelSessions();
 }
 
-export async function getWorkspaceOverride(botName: string): Promise<WorkspaceOverride | null> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const row = db.prepare('SELECT * FROM workspace_overrides WHERE bot_name = ?').get(botName) as any;
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getWorkspaceOverride took ${elapsed.toFixed(0)}ms`);
-    if (!row) return null;
-    return {
-      botName: row.bot_name,
-      workingDirectory: row.working_directory,
-      allowPaths: safeParseAllowPaths(row.allow_paths),
-      createdAt: row.created_at,
-    };
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getWorkspaceOverride CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getWorkspaceOverride CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getWorkspaceOverride - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getWorkspaceOverride - database is read-only:', err);
-    else log.error('getWorkspaceOverride failed:', err);
-    throw err;
-  }
+// -- Preferences ------------------------------------------------------------
+export async function getChannelPrefs(channelId: string) {
+  return store().getChannelPrefs(channelId);
+}
+export async function setChannelPrefs(channelId: string, prefs: Parameters<StateStore['setChannelPrefs']>[1]) {
+  return store().setChannelPrefs(channelId, prefs);
 }
 
-export async function setWorkspaceOverride(botName: string, workingDirectory: string, allowPaths?: string[]): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare(
-      `INSERT INTO workspace_overrides (bot_name, working_directory, allow_paths, created_at)
-       VALUES (?, ?, ?, datetime('now'))
-       ON CONFLICT(bot_name) DO UPDATE SET
-         working_directory = excluded.working_directory,
-         allow_paths = excluded.allow_paths`
-    ).run(botName, workingDirectory, JSON.stringify(allowPaths ?? []));
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`setWorkspaceOverride took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('setWorkspaceOverride CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('setWorkspaceOverride CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('setWorkspaceOverride - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('setWorkspaceOverride - database is read-only:', err);
-    else log.error('setWorkspaceOverride failed:', err);
-    throw err;
-  }
+// -- Permissions ------------------------------------------------------------
+export async function getPermissionRules(scope: string, tool: string) {
+  return store().getPermissionRules(scope, tool);
+}
+export async function addPermissionRule(scope: string, tool: string, commandPattern: string, action: 'allow' | 'deny') {
+  return store().addPermissionRule(scope, tool, commandPattern, action);
+}
+export async function clearPermissionRules(scope: string) {
+  return store().clearPermissionRules(scope);
+}
+export async function removePermissionRule(scope: string, tool: string, commandPattern: string) {
+  return store().removePermissionRule(scope, tool, commandPattern);
+}
+export async function listPermissionRulesForScope(scope: string) {
+  return store().listPermissionRulesForScope(scope);
+}
+export async function checkPermission(scope: string, tool: string, command: string) {
+  return store().checkPermission(scope, tool, command);
 }
 
-export async function removeWorkspaceOverride(botName: string): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare('DELETE FROM workspace_overrides WHERE bot_name = ?').run(botName);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`removeWorkspaceOverride took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('removeWorkspaceOverride CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('removeWorkspaceOverride CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('removeWorkspaceOverride - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('removeWorkspaceOverride - database is read-only:', err);
-    else log.error('removeWorkspaceOverride failed:', err);
-    throw err;
-  }
+// -- Workspaces -------------------------------------------------------------
+export async function getWorkspaceOverride(botName: string) {
+  return store().getWorkspaceOverride(botName);
+}
+export async function setWorkspaceOverride(botName: string, workingDirectory: string, allowPaths?: string[]) {
+  return store().setWorkspaceOverride(botName, workingDirectory, allowPaths);
+}
+export async function removeWorkspaceOverride(botName: string) {
+  return store().removeWorkspaceOverride(botName);
+}
+export async function listWorkspaceOverrides() {
+  return store().listWorkspaceOverrides();
 }
 
-export async function listWorkspaceOverrides(): Promise<WorkspaceOverride[]> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const rows = db.prepare('SELECT * FROM workspace_overrides').all() as any[];
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`listWorkspaceOverrides took ${elapsed.toFixed(0)}ms`);
-    return rows.map(row => ({
-      botName: row.bot_name,
-      workingDirectory: row.working_directory,
-      allowPaths: safeParseAllowPaths(row.allow_paths),
-      createdAt: row.created_at,
-    }));
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('listWorkspaceOverrides CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('listWorkspaceOverrides CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('listWorkspaceOverrides - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('listWorkspaceOverrides - database is read-only:', err);
-    else log.error('listWorkspaceOverrides failed:', err);
-    throw err;
-  }
+// -- Settings ---------------------------------------------------------------
+export async function getGlobalSetting(key: string) {
+  return store().getGlobalSetting(key);
+}
+export async function setGlobalSetting(key: string, value: string) {
+  return store().setGlobalSetting(key, value);
 }
 
-// --- Global Settings ---
-
-export async function getGlobalSetting(key: string): Promise<string | null> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getGlobalSetting took ${elapsed.toFixed(0)}ms`);
-    return row?.value ?? null;
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getGlobalSetting CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getGlobalSetting CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getGlobalSetting - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getGlobalSetting - database is read-only:', err);
-    else log.error('getGlobalSetting failed:', err);
-    throw err;
-  }
+// -- Dynamic Channels -------------------------------------------------------
+export async function addDynamicChannel(channel: Parameters<StateStore['addDynamicChannel']>[0]) {
+  return store().addDynamicChannel(channel);
+}
+export async function removeDynamicChannel(channelId: string) {
+  return store().removeDynamicChannel(channelId);
+}
+export async function getDynamicChannel(channelId: string) {
+  return store().getDynamicChannel(channelId);
+}
+export async function getDynamicChannels() {
+  return store().getDynamicChannels();
 }
 
-export async function setGlobalSetting(key: string, value: string): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare(
-      `INSERT INTO settings (key, value) VALUES (?, ?)
-       ON CONFLICT(key) DO UPDATE SET value = excluded.value`
-    ).run(key, value);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`setGlobalSetting took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('setGlobalSetting CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('setGlobalSetting CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('setGlobalSetting - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('setGlobalSetting - database is read-only:', err);
-    else log.error('setGlobalSetting failed:', err);
-    throw err;
-  }
+// -- Agent Calls ------------------------------------------------------------
+export async function recordAgentCall(record: Parameters<StateStore['recordAgentCall']>[0]) {
+  return store().recordAgentCall(record);
+}
+export async function getRecentAgentCalls(limit?: number) {
+  return store().getRecentAgentCalls(limit);
 }
 
-// --- Dynamic Channels ---
-
-export interface DynamicChannel {
-  channelId: string;
-  platform: string;
-  name: string;
-  bot?: string;
-  workingDirectory: string;
-  agent?: string | null;
-  model?: string;
-  triggerMode?: 'mention' | 'all';
-  threadedReplies?: boolean;
-  verbose?: boolean;
-  isDM: boolean;
-  createdAt: string;
-  updatedAt: string;
+// -- Scheduling -------------------------------------------------------------
+export async function insertScheduledTask(task: Parameters<StateStore['insertScheduledTask']>[0]) {
+  return store().insertScheduledTask(task);
+}
+export async function getScheduledTask(id: string) {
+  return store().getScheduledTask(id);
+}
+export async function getScheduledTasksForChannel(channelId: string) {
+  return store().getScheduledTasksForChannel(channelId);
+}
+export async function getEnabledScheduledTasks() {
+  return store().getEnabledScheduledTasks();
+}
+export async function updateScheduledTaskEnabled(id: string, enabled: boolean) {
+  return store().updateScheduledTaskEnabled(id, enabled);
+}
+export async function updateScheduledTaskLastRun(id: string, lastRun: string, nextRun?: string) {
+  return store().updateScheduledTaskLastRun(id, lastRun, nextRun);
+}
+export async function deleteScheduledTask(id: string) {
+  return store().deleteScheduledTask(id);
+}
+export async function insertTaskHistory(entry: Parameters<StateStore['insertTaskHistory']>[0]) {
+  return store().insertTaskHistory(entry);
+}
+export async function getTaskHistory(channelId: string, limit?: number) {
+  return store().getTaskHistory(channelId, limit);
 }
 
-export async function addDynamicChannel(channel: Omit<DynamicChannel, 'createdAt' | 'updatedAt'>): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare(
-      `INSERT INTO dynamic_channels (channel_id, platform, name, bot, working_directory, agent, model, trigger_mode, threaded_replies, verbose, is_dm)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(channel_id) DO UPDATE SET
-         platform = excluded.platform, name = excluded.name, bot = excluded.bot,
-         working_directory = excluded.working_directory, agent = excluded.agent,
-         model = excluded.model, trigger_mode = excluded.trigger_mode,
-         threaded_replies = excluded.threaded_replies, verbose = excluded.verbose,
-         is_dm = excluded.is_dm, updated_at = datetime('now')`
-    ).run(
-      channel.channelId,
-      channel.platform,
-      channel.name ?? '',
-      channel.bot ?? null,
-      channel.workingDirectory,
-      channel.agent ?? null,
-      channel.model ?? null,
-      channel.triggerMode ?? null,
-      channel.threadedReplies != null ? (channel.threadedReplies ? 1 : 0) : null,
-      channel.verbose != null ? (channel.verbose ? 1 : 0) : null,
-      channel.isDM ? 1 : 0,
-    );
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`addDynamicChannel took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('addDynamicChannel CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('addDynamicChannel CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('addDynamicChannel - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('addDynamicChannel - database is read-only:', err);
-    else log.error('addDynamicChannel failed:', err);
-    throw err;
-  }
-}
-
-export async function removeDynamicChannel(channelId: string): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare('DELETE FROM dynamic_channels WHERE channel_id = ?').run(channelId);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`removeDynamicChannel took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('removeDynamicChannel CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('removeDynamicChannel CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('removeDynamicChannel - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('removeDynamicChannel - database is read-only:', err);
-    else log.error('removeDynamicChannel failed:', err);
-    throw err;
-  }
-}
-
-export async function getDynamicChannel(channelId: string): Promise<DynamicChannel | null> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const row = db.prepare('SELECT * FROM dynamic_channels WHERE channel_id = ?').get(channelId) as any;
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getDynamicChannel took ${elapsed.toFixed(0)}ms`);
-    if (!row) return null;
-    return mapDynamicChannelRow(row);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getDynamicChannel CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getDynamicChannel CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getDynamicChannel - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getDynamicChannel - database is read-only:', err);
-    else log.error('getDynamicChannel failed:', err);
-    throw err;
-  }
-}
-
-export async function getDynamicChannels(): Promise<DynamicChannel[]> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const rows = db.prepare('SELECT * FROM dynamic_channels ORDER BY created_at').all() as any[];
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getDynamicChannels took ${elapsed.toFixed(0)}ms`);
-    return rows.map(mapDynamicChannelRow);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getDynamicChannels CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getDynamicChannels CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getDynamicChannels - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getDynamicChannels - database is read-only:', err);
-    else log.error('getDynamicChannels failed:', err);
-    throw err;
-  }
-}
-
-function mapDynamicChannelRow(row: any): DynamicChannel {
-  return {
-    channelId: row.channel_id,
-    platform: row.platform,
-    name: row.name,
-    bot: row.bot ?? undefined,
-    workingDirectory: row.working_directory,
-    agent: row.agent,
-    model: row.model ?? undefined,
-    triggerMode: row.trigger_mode as 'mention' | 'all' | undefined,
-    threadedReplies: row.threaded_replies != null ? !!row.threaded_replies : undefined,
-    verbose: row.verbose != null ? !!row.verbose : undefined,
-    isDM: !!row.is_dm,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  };
-}
-
-// --- Agent Calls (inter-agent audit trail) ---
-
-export interface AgentCallRecord {
-  callerBot: string;
-  targetBot: string;
-  targetAgent?: string;
-  messageSummary?: string;
-  responseSummary?: string;
-  durationMs?: number;
-  success: boolean;
-  error?: string;
-  chainId?: string;
-  depth?: number;
-}
-
-export async function recordAgentCall(record: AgentCallRecord): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare(
-      `INSERT INTO agent_calls (caller_bot, target_bot, target_agent, message_summary, response_summary, duration_ms, success, error, chain_id, depth)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      record.callerBot,
-      record.targetBot,
-      record.targetAgent ?? null,
-      record.messageSummary ?? null,
-      record.responseSummary ?? null,
-      record.durationMs ?? null,
-      record.success ? 1 : 0,
-      record.error ?? null,
-      record.chainId ?? null,
-      record.depth ?? 0,
-    );
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`recordAgentCall took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('recordAgentCall CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('recordAgentCall CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('recordAgentCall - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('recordAgentCall - database is read-only:', err);
-    else log.error('recordAgentCall failed:', err);
-    throw err;
-  }
-}
-
-export async function getRecentAgentCalls(limit: number = 20): Promise<Array<AgentCallRecord & { id: number; createdAt: string }>> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const rows = db.prepare(
-      'SELECT * FROM agent_calls ORDER BY created_at DESC LIMIT ?'
-    ).all(limit) as any[];
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getRecentAgentCalls took ${elapsed.toFixed(0)}ms`);
-    return rows.map(r => ({
-      id: r.id,
-      callerBot: r.caller_bot,
-      targetBot: r.target_bot,
-      targetAgent: r.target_agent ?? undefined,
-      messageSummary: r.message_summary ?? undefined,
-      responseSummary: r.response_summary ?? undefined,
-      durationMs: r.duration_ms ?? undefined,
-      success: !!r.success,
-      error: r.error ?? undefined,
-      chainId: r.chain_id ?? undefined,
-      depth: r.depth ?? 0,
-      createdAt: r.created_at,
-    }));
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getRecentAgentCalls CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getRecentAgentCalls CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getRecentAgentCalls - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getRecentAgentCalls - database is read-only:', err);
-    else log.error('getRecentAgentCalls failed:', err);
-    throw err;
-  }
-}
-
-// --- Scheduled Tasks ---
-
-export interface ScheduledTask {
-  id: string;
-  channelId: string;
-  botName: string;
-  prompt: string;
-  cronExpr?: string;
-  runAt?: string;
-  timezone: string;
-  createdBy?: string;
-  description?: string;
-  enabled: boolean;
-  lastRun?: string;
-  nextRun?: string;
-  createdAt: string;
-}
-
-export async function insertScheduledTask(task: Omit<ScheduledTask, 'createdAt' | 'lastRun' | 'nextRun'> & { nextRun?: string }): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare(`
-      INSERT INTO scheduled_tasks (id, channel_id, bot_name, prompt, cron_expr, run_at, timezone, created_by, description, enabled, next_run)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      task.id, task.channelId, task.botName, task.prompt,
-      task.cronExpr ?? null, task.runAt ?? null, task.timezone,
-      task.createdBy ?? null, task.description ?? null,
-      task.enabled ? 1 : 0, task.nextRun ?? null,
-    );
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`insertScheduledTask took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('insertScheduledTask CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('insertScheduledTask CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('insertScheduledTask - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('insertScheduledTask - database is read-only:', err);
-    else log.error('insertScheduledTask failed:', err);
-    throw err;
-  }
-}
-
-export async function getScheduledTask(id: string): Promise<ScheduledTask | null> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const row = db.prepare('SELECT * FROM scheduled_tasks WHERE id = ?').get(id) as any;
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getScheduledTask took ${elapsed.toFixed(0)}ms`);
-    return row ? mapTaskRow(row) : null;
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getScheduledTask CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getScheduledTask CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getScheduledTask - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getScheduledTask - database is read-only:', err);
-    else log.error('getScheduledTask failed:', err);
-    throw err;
-  }
-}
-
-export async function getScheduledTasksForChannel(channelId: string): Promise<ScheduledTask[]> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    // Show enabled tasks + paused recurring tasks (exclude disabled one-offs — they're finished)
-    const rows = db.prepare(
-      'SELECT * FROM scheduled_tasks WHERE channel_id = ? AND (enabled = 1 OR cron_expr IS NOT NULL) ORDER BY created_at DESC'
-    ).all(channelId) as any[];
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getScheduledTasksForChannel took ${elapsed.toFixed(0)}ms`);
-    return rows.map(mapTaskRow);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getScheduledTasksForChannel CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getScheduledTasksForChannel CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getScheduledTasksForChannel - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getScheduledTasksForChannel - database is read-only:', err);
-    else log.error('getScheduledTasksForChannel failed:', err);
-    throw err;
-  }
-}
-
-export async function getEnabledScheduledTasks(): Promise<ScheduledTask[]> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const rows = db.prepare('SELECT * FROM scheduled_tasks WHERE enabled = 1').all() as any[];
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getEnabledScheduledTasks took ${elapsed.toFixed(0)}ms`);
-    return rows.map(mapTaskRow);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getEnabledScheduledTasks CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getEnabledScheduledTasks CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getEnabledScheduledTasks - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getEnabledScheduledTasks - database is read-only:', err);
-    else log.error('getEnabledScheduledTasks failed:', err);
-    throw err;
-  }
-}
-
-export async function updateScheduledTaskEnabled(id: string, enabled: boolean): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare('UPDATE scheduled_tasks SET enabled = ? WHERE id = ?').run(enabled ? 1 : 0, id);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`updateScheduledTaskEnabled took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('updateScheduledTaskEnabled CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('updateScheduledTaskEnabled CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('updateScheduledTaskEnabled - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('updateScheduledTaskEnabled - database is read-only:', err);
-    else log.error('updateScheduledTaskEnabled failed:', err);
-    throw err;
-  }
-}
-
-export async function updateScheduledTaskLastRun(id: string, lastRun: string, nextRun?: string): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare('UPDATE scheduled_tasks SET last_run = ?, next_run = ? WHERE id = ?').run(lastRun, nextRun ?? null, id);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`updateScheduledTaskLastRun took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('updateScheduledTaskLastRun CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('updateScheduledTaskLastRun CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('updateScheduledTaskLastRun - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('updateScheduledTaskLastRun - database is read-only:', err);
-    else log.error('updateScheduledTaskLastRun failed:', err);
-    throw err;
-  }
-}
-
-export async function deleteScheduledTask(id: string): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare('DELETE FROM scheduled_tasks WHERE id = ?').run(id);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`deleteScheduledTask took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('deleteScheduledTask CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('deleteScheduledTask CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('deleteScheduledTask - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('deleteScheduledTask - database is read-only:', err);
-    else log.error('deleteScheduledTask failed:', err);
-    throw err;
-  }
-}
-
-function mapTaskRow(r: any): ScheduledTask {
-  return {
-    id: r.id,
-    channelId: r.channel_id,
-    botName: r.bot_name,
-    prompt: r.prompt,
-    cronExpr: r.cron_expr ?? undefined,
-    runAt: r.run_at ?? undefined,
-    timezone: r.timezone,
-    createdBy: r.created_by ?? undefined,
-    description: r.description ?? undefined,
-    enabled: !!r.enabled,
-    lastRun: r.last_run ?? undefined,
-    nextRun: r.next_run ?? undefined,
-    createdAt: r.created_at,
-  };
-}
-
-// --- Scheduled Task History ---
-
-export interface TaskHistoryEntry {
-  id: number;
-  taskId: string;
-  channelId: string;
-  prompt: string;
-  description?: string;
-  timezone: string;
-  status: 'success' | 'error';
-  firedAt: string;
-  error?: string;
-}
-
-export async function insertTaskHistory(entry: Omit<TaskHistoryEntry, 'id' | 'firedAt'>): Promise<void> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    db.prepare(`
-      INSERT INTO scheduled_task_history (task_id, channel_id, prompt, description, timezone, status, fired_at, error)
-      VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)
-    `).run(entry.taskId, entry.channelId, entry.prompt, entry.description ?? null, entry.timezone, entry.status, entry.error ?? null);
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`insertTaskHistory took ${elapsed.toFixed(0)}ms`);
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('insertTaskHistory CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('insertTaskHistory CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('insertTaskHistory - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('insertTaskHistory - database is read-only:', err);
-    else log.error('insertTaskHistory failed:', err);
-    throw err;
-  }
-}
-
-export async function getTaskHistory(channelId: string, limit = 20): Promise<TaskHistoryEntry[]> {
-  try {
-    const start = performance.now();
-    const db = getDb();
-    const rows = db.prepare(
-      'SELECT * FROM scheduled_task_history WHERE channel_id = ? ORDER BY fired_at DESC LIMIT ?'
-    ).all(channelId, limit) as any[];
-    const elapsed = performance.now() - start;
-    if (elapsed > SLOW_QUERY_MS) log.warn(`getTaskHistory took ${elapsed.toFixed(0)}ms`);
-    return rows.map(r => ({
-      id: r.id,
-      taskId: r.task_id,
-      channelId: r.channel_id,
-      prompt: r.prompt,
-      description: r.description ?? undefined,
-      timezone: r.timezone ?? 'UTC',
-      status: r.status,
-      firedAt: r.fired_at,
-      error: r.error ?? undefined,
-    }));
-  } catch (err) {
-    const kind = classifyDbError(err);
-    if (kind === 'corrupt') log.error('getTaskHistory CRITICAL - database may be corrupt:', err);
-    else if (kind === 'full') log.error('getTaskHistory CRITICAL - disk full:', err);
-    else if (kind === 'busy') log.warn('getTaskHistory - database busy (contention):', err);
-    else if (kind === 'readonly') log.error('getTaskHistory - database is read-only:', err);
-    else log.error('getTaskHistory failed:', err);
-    throw err;
-  }
-}
-
-// --- Cleanup ---
-
+// -- Lifecycle --------------------------------------------------------------
 export async function closeDb(): Promise<void> {
+  if (!_store) return;
   try {
-    _db?.close();
+    await _store.close();
   } catch (err) {
     log.warn('Failed to close database cleanly:', err);
   } finally {
-    _db = null;
+    _store = null;
   }
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -37,10 +37,13 @@ function store(): StateStore {
     // (tests and code that call store functions before explicit initStore)
     log.warn('Store accessed before initStore() — auto-initializing with defaults');
     const sqlite = new SqliteStateStore();
-    // Synchronous field assignment; initialize() will be called on first real use
     _store = sqlite;
-    // Fire-and-forget init — better-sqlite3 is synchronous so this resolves immediately
-    void sqlite.initialize();
+    // better-sqlite3 is synchronous so this resolves immediately, but catch
+    // any failure so it's never silently swallowed
+    sqlite.initialize().catch((err) => {
+      log.error('Auto-initialization of default SQLite store failed:', err);
+      _store = null;
+    });
   }
   return _store;
 }
@@ -58,7 +61,12 @@ function store(): StateStore {
 export async function initStore(customStore?: StateStore, dbPath?: string): Promise<void> {
   if (_store) {
     log.warn('initStore called when store already initialized — closing previous instance');
-    await closeDb();
+    try {
+      await _store.close();
+    } catch (err) {
+      log.warn('Failed to close previous store during re-init:', err);
+    }
+    _store = null;
   }
   _store = customStore ?? new SqliteStateStore(dbPath);
   await _store.initialize();
@@ -191,9 +199,13 @@ export async function getTaskHistory(channelId: string, limit?: number) {
 
 // -- Lifecycle --------------------------------------------------------------
 export async function closeDb(): Promise<void> {
-  if (!_store) return;
+  if (!_store) {
+    log.debug('closeDb called but store is already null — no-op');
+    return;
+  }
   try {
     await _store.close();
+    log.info('State store closed');
   } catch (err) {
     log.warn('Failed to close database cleanly:', err);
   } finally {

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,0 +1,234 @@
+/**
+ * Pluggable state store interface and shared types for copilot-bridge.
+ *
+ * All persistence backends (SQLite, Postgres, etc.) implement the
+ * {@link StateStore} interface. The data types below are shared across
+ * every implementation and the rest of the codebase.
+ */
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+export interface ChannelPrefs {
+  model?: string;
+  provider?: string | null;
+  agent?: string | null;
+  verbose?: boolean;
+  threadedReplies?: boolean;
+  permissionMode?: string;
+  reasoningEffort?: string | null;
+  sessionMode?: string;
+  disabledSkills?: string[];
+}
+
+export interface StoredPermissionRule {
+  id: number;
+  scope: string;
+  tool: string;
+  commandPattern: string;
+  action: 'allow' | 'deny';
+  createdAt: string;
+}
+
+export interface WorkspaceOverride {
+  botName: string;
+  workingDirectory: string;
+  allowPaths: string[];
+  createdAt: string;
+}
+
+export interface DynamicChannel {
+  channelId: string;
+  platform: string;
+  name: string;
+  bot?: string;
+  workingDirectory: string;
+  agent?: string | null;
+  model?: string;
+  triggerMode?: 'mention' | 'all';
+  threadedReplies?: boolean;
+  verbose?: boolean;
+  isDM: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AgentCallRecord {
+  callerBot: string;
+  targetBot: string;
+  targetAgent?: string;
+  messageSummary?: string;
+  responseSummary?: string;
+  durationMs?: number;
+  success: boolean;
+  error?: string;
+  chainId?: string;
+  depth?: number;
+}
+
+export interface ScheduledTask {
+  id: string;
+  channelId: string;
+  botName: string;
+  prompt: string;
+  cronExpr?: string;
+  runAt?: string;
+  timezone: string;
+  createdBy?: string;
+  description?: string;
+  enabled: boolean;
+  lastRun?: string;
+  nextRun?: string;
+  createdAt: string;
+}
+
+export interface TaskHistoryEntry {
+  id: number;
+  taskId: string;
+  channelId: string;
+  prompt: string;
+  description?: string;
+  timezone: string;
+  status: 'success' | 'error';
+  firedAt: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// StateStore interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Contract for pluggable persistence backends.
+ *
+ * Every method is async so implementations can use network-backed stores
+ * (Postgres, Redis, etc.) without blocking the event loop.
+ */
+export interface StateStore {
+  // -- Lifecycle -------------------------------------------------------------
+
+  /** Create tables / run migrations. Called once at startup. */
+  initialize(): Promise<void>;
+
+  /** Release connections and clean up resources. */
+  close(): Promise<void>;
+
+  /** Return `true` if the backing store is reachable. */
+  ping(): Promise<boolean>;
+
+  // -- Sessions --------------------------------------------------------------
+
+  /** Get the active Copilot session ID for a channel, or `null`. */
+  getChannelSession(channelId: string): Promise<string | null>;
+
+  /** Persist the active session ID for a channel. */
+  setChannelSession(channelId: string, sessionId: string): Promise<void>;
+
+  /** Remove the stored session for a channel. */
+  clearChannelSession(channelId: string): Promise<void>;
+
+  /** List every channel → session mapping. */
+  getAllChannelSessions(): Promise<Array<{ channelId: string; sessionId: string }>>;
+
+  // -- Preferences -----------------------------------------------------------
+
+  /** Read per-channel preferences, or `null` if none are stored. */
+  getChannelPrefs(channelId: string): Promise<ChannelPrefs | null>;
+
+  /** Merge partial preferences into the stored record for a channel. */
+  setChannelPrefs(channelId: string, prefs: Partial<ChannelPrefs>): Promise<void>;
+
+  // -- Permissions -----------------------------------------------------------
+
+  /** Fetch permission rules matching a scope and tool. */
+  getPermissionRules(scope: string, tool: string): Promise<StoredPermissionRule[]>;
+
+  /** Add a permission rule for a scope/tool/pattern combination. */
+  addPermissionRule(scope: string, tool: string, commandPattern: string, action: 'allow' | 'deny'): Promise<void>;
+
+  /** Remove all permission rules for a scope. */
+  clearPermissionRules(scope: string): Promise<void>;
+
+  /** Remove a single permission rule. Returns `true` if a row was deleted. */
+  removePermissionRule(scope: string, tool: string, commandPattern: string): Promise<boolean>;
+
+  /** List every permission rule for a scope. */
+  listPermissionRulesForScope(scope: string): Promise<StoredPermissionRule[]>;
+
+  /** Evaluate rules and return the action, or `null` if no rule matches. */
+  checkPermission(scope: string, tool: string, command: string): Promise<'allow' | 'deny' | null>;
+
+  // -- Workspaces ------------------------------------------------------------
+
+  /** Get the workspace override for a bot, or `null`. */
+  getWorkspaceOverride(botName: string): Promise<WorkspaceOverride | null>;
+
+  /** Set (upsert) the workspace override for a bot. */
+  setWorkspaceOverride(botName: string, workingDirectory: string, allowPaths?: string[]): Promise<void>;
+
+  /** Remove the workspace override for a bot. */
+  removeWorkspaceOverride(botName: string): Promise<void>;
+
+  /** List all workspace overrides. */
+  listWorkspaceOverrides(): Promise<WorkspaceOverride[]>;
+
+  // -- Settings --------------------------------------------------------------
+
+  /** Read a global key-value setting, or `null`. */
+  getGlobalSetting(key: string): Promise<string | null>;
+
+  /** Write a global key-value setting. */
+  setGlobalSetting(key: string, value: string): Promise<void>;
+
+  // -- Dynamic Channels ------------------------------------------------------
+
+  /** Register a dynamic channel. */
+  addDynamicChannel(channel: Omit<DynamicChannel, 'createdAt' | 'updatedAt'>): Promise<void>;
+
+  /** Unregister a dynamic channel. */
+  removeDynamicChannel(channelId: string): Promise<void>;
+
+  /** Get a single dynamic channel by ID, or `null`. */
+  getDynamicChannel(channelId: string): Promise<DynamicChannel | null>;
+
+  /** List all dynamic channels. */
+  getDynamicChannels(): Promise<DynamicChannel[]>;
+
+  // -- Agent Calls -----------------------------------------------------------
+
+  /** Record an inter-agent call for audit/debugging. */
+  recordAgentCall(record: AgentCallRecord): Promise<void>;
+
+  /** Fetch the most recent agent call records. */
+  getRecentAgentCalls(limit?: number): Promise<Array<AgentCallRecord & { id: number; createdAt: string }>>;
+
+  // -- Scheduling ------------------------------------------------------------
+
+  /** Insert a new scheduled task. */
+  insertScheduledTask(task: Omit<ScheduledTask, 'createdAt' | 'lastRun' | 'nextRun'> & { nextRun?: string }): Promise<void>;
+
+  /** Get a scheduled task by ID, or `null`. */
+  getScheduledTask(id: string): Promise<ScheduledTask | null>;
+
+  /** List scheduled tasks for a channel. */
+  getScheduledTasksForChannel(channelId: string): Promise<ScheduledTask[]>;
+
+  /** List all enabled scheduled tasks. */
+  getEnabledScheduledTasks(): Promise<ScheduledTask[]>;
+
+  /** Enable or disable a scheduled task. */
+  updateScheduledTaskEnabled(id: string, enabled: boolean): Promise<void>;
+
+  /** Update the last-run timestamp (and optionally next-run) for a task. */
+  updateScheduledTaskLastRun(id: string, lastRun: string, nextRun?: string): Promise<void>;
+
+  /** Delete a scheduled task. */
+  deleteScheduledTask(id: string): Promise<void>;
+
+  /** Record a task execution in history. */
+  insertTaskHistory(entry: Omit<TaskHistoryEntry, 'id' | 'firedAt'>): Promise<void>;
+
+  /** Fetch task execution history for a channel. */
+  getTaskHistory(channelId: string, limit?: number): Promise<TaskHistoryEntry[]>;
+}

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -117,6 +117,9 @@ export interface StateStore {
   /** Return `true` if the backing store is reachable. */
   ping(): Promise<boolean>;
 
+  /** Run a set of operations atomically. Implementations handle isolation internally. */
+  withTransaction<T>(fn: () => Promise<T>): Promise<T>;
+
   // -- Sessions --------------------------------------------------------------
 
   /** Get the active Copilot session ID for a channel, or `null`. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,14 @@ export interface AppConfig {
   interAgent?: InterAgentConfig;
   providers?: Record<string, BridgeProviderConfig>;
   telemetry?: BridgeTelemetryConfig;
+  database?: DatabaseConfig;
+}
+
+export interface DatabaseConfig {
+  /** Path to a JS/TS module exporting a StateStore class as its default export. */
+  module: string;
+  /** Arbitrary options passed to the custom store constructor. */
+  options?: Record<string, unknown>;
 }
 
 // Inter-agent communication config

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,7 @@ export interface AppConfig {
 }
 
 export interface DatabaseConfig {
-  /** Path to a JS/TS module exporting a StateStore class as its default export. */
+  /** Path to a JS/TS module that provides a StateStore implementation (default export, named `StateStore` export, or the module object itself). */
   module: string;
   /** Arbitrary options passed to the custom store constructor. */
   options?: Record<string, unknown>;


### PR DESCRIPTION
Closes #176

## Summary

Makes the database layer pluggable via a `StateStore` interface. Third-party backends (Postgres, Redis, etc.) can be swapped in without touching application code.

## Changes

### Architecture
- **`src/state/types.ts`** -- `StateStore` interface (34 methods + lifecycle) and 7 shared data types
- **`src/state/sqlite-store.ts`** -- `SqliteStateStore` class (built-in default, wraps better-sqlite3)
- **`src/state/store.ts`** -- Thin facade (1184 -> 202 lines). All 34 exported functions delegate to the active `StateStore` instance. Zero caller changes needed.

### Plugin Loading
- **`src/types.ts`** -- `DatabaseConfig` on `AppConfig` (`database.module` + `database.options`)
- **`src/config.ts`** -- Passes `database` field through config validation
- **`src/index.ts`** -- Dynamic import of custom modules at startup with validation:
  - Resolves relative paths against CWD (not dist/)
  - Supports default and named ESM exports
  - Validates 8 core StateStore methods before accepting

### Observability
- Schema migrations log applied/skipped/failed with labels (not silently swallowed)
- `ping()`, `close()`, `closeDb()` all log appropriately
- Auto-init fallback catches initialization errors
- Fatal error handler logs closeDb() failures

### Tests (68 new, 659 total)
- **`store.test.ts`** -- initStore lifecycle, closeDb, facade delegation, type exports
- **`sqlite-store.test.ts`** -- Full CRUD coverage: sessions, prefs, permissions, workspaces, settings, dynamic channels, scheduled tasks, error handling

### Documentation
- **AGENTS.md** -- State Persistence section updated
- **docs/architecture.md** -- Source layout + persistence section
- **docs/configuration.md** -- New Database section with config reference
- **config.sample.json** -- Example database config

## Design Decisions

- **Facade pattern** -- Callers import the same functions from the same path. The interface swap is invisible to the rest of the codebase.
- **Auto-init fallback** -- If store functions are called before explicit `initStore()`, the facade auto-initializes with SQLite defaults and logs a warning. This preserves backward compatibility for tests and any code that doesn't go through main().
- **Explicit lifecycle** -- `initialize()` is called once at startup (not lazy-init) so plugin loading can await it and fail fast.

