### PR TITLE
fix: add MCP server logging and delete empty stream messages

### DIFF
--- a/src/channels/mattermost/streaming.ts
+++ b/src/channels/mattermost/streaming.ts
@@ -102,6 +102,14 @@ export class StreamingHandler {
       } catch (err) {
         log.error(`Failed to finalize message:`, err);
       }
+    } else {
+      // No content (e.g. no_reply) — delete the placeholder "Working..." message
+      try {
+        await this.adapter.deleteMessage(stream.channelId, stream.messageId);
+        log.info(`Deleted empty stream message ${stream.messageId.slice(0, 8)}...`);
+      } catch (err) {
+        log.warn(`Failed to delete empty stream message:`, err);
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2044,6 +2044,29 @@ async function handleSessionEvent(
     log.debug(`SDK ${event.type}: ${JSON.stringify(event.data).slice(0, 200)}`);
   } else if (event.type === 'session.compaction_start' || event.type === 'session.compaction_complete') {
     // Already logged above; skip duplicate debug line
+  } else if (event.type === 'session.mcp_servers_loaded') {
+    const servers = (event.data as Record<string, unknown>)?.servers;
+    if (Array.isArray(servers)) {
+      const failed = servers.filter((s: Record<string, unknown>) => s.status === 'failed');
+      if (failed.length > 0) {
+        for (const s of failed) {
+          log.warn(`MCP server "${s.name}" failed to connect: ${s.error || 'unknown error'}`);
+        }
+      }
+      const names = servers.map((s: Record<string, unknown>) => `${s.name} (${s.status})`).join(', ');
+      log.info(`MCP servers loaded: ${names}`);
+    } else {
+      log.info(`SDK ${event.type}: ${JSON.stringify(event.data).slice(0, 500)}`);
+    }
+  } else if (event.type === 'session.mcp_server_status_changed') {
+    const d = event.data as Record<string, unknown>;
+    if (d?.status === 'failed') {
+      log.warn(`MCP server "${d.name}" status changed to failed: ${d.error || 'unknown error'}`);
+    } else {
+      log.info(`MCP server "${d?.name}" status: ${d?.status}`);
+    }
+  } else if (event.type?.startsWith('mcp.')) {
+    log.info(`SDK ${event.type}: ${JSON.stringify(event.data).slice(0, 500)}`);
   } else {
     log.debug(`SDK event: ${event.type}`);
   }


### PR DESCRIPTION
## Changes

- **MCP server load logging** -- Log all MCP server statuses at INFO when `session.mcp_servers_loaded` fires. WARN for any servers that failed to connect, with error details.
- **MCP server runtime status** -- Log `session.mcp_server_status_changed` events at INFO (WARN for failures), so mid-session server disconnects are visible.
- **MCP event logging** -- Log `mcp.*` events (e.g. `mcp.oauth_required`) at INFO instead of swallowing them in the generic debug handler.
- **Delete empty stream messages** -- When a stream finalizes with no content (e.g. after `no_reply`), delete the "Working..." placeholder instead of leaving it orphaned in chat.

## Context

The MCP logging was identified during investigation of #95 (HTTP MCP servers silently failing). Without these changes, a failed MCP server was completely invisible in logs -- the `session.mcp_servers_loaded` event data was dropped by the generic handler.

The empty stream fix addresses a regression where `no_reply` left a stuck "Working..." message. The stream finalized with 0 chars, which was falsy, so `finalizeStream` neither updated nor deleted the placeholder.

Closes #169 (properly this time -- the earlier close addressed suppression but missed the empty stream case).