### PR TITLE
chore: update dependencies, fix agent resolution & skill discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "@chrisromp/copilot-bridge",
       "version": "0.13.0",
       "dependencies": {
-        "@github/copilot-sdk": "^0.2.0",
+        "@github/copilot-sdk": "^0.2.2",
         "@mattermost/client": "^11.5.0",
         "@mattermost/types": "^11.5.0",
-        "@slack/bolt": "^4.6.0",
+        "@slack/bolt": "^4.7.0",
         "better-sqlite3": "^12.6.2",
         "cron": "^4.4.0",
         "cronstrue": "^3.14.0",
@@ -26,45 +26,42 @@
         "@types/better-sqlite3": "^7.6.12",
         "@types/ws": "^8.5.14",
         "typescript": "^5.9.3",
-        "vitest": "^4.1.2"
+        "vitest": "^4.1.4"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -486,26 +483,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.11.tgz",
-      "integrity": "sha512-cptVopko/tNKEXyBP174yBjHQBEwg6CqaKN2S0M3J+5LEB8u31bLL75ioOPd+5vubqBrA0liyTdcHeZ8UTRbmg==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.23.tgz",
+      "integrity": "sha512-YUx8ksTEy8LjZ9PrYxT/LcZlDsX+nceNar1BGIiwnvtDvaf5bLSoo7ZkGKlBjK14WQ0KldWLk4K4MOBK4e1dEg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.11",
-        "@github/copilot-darwin-x64": "1.0.11",
-        "@github/copilot-linux-arm64": "1.0.11",
-        "@github/copilot-linux-x64": "1.0.11",
-        "@github/copilot-win32-arm64": "1.0.11",
-        "@github/copilot-win32-x64": "1.0.11"
+        "@github/copilot-darwin-arm64": "1.0.23",
+        "@github/copilot-darwin-x64": "1.0.23",
+        "@github/copilot-linux-arm64": "1.0.23",
+        "@github/copilot-linux-x64": "1.0.23",
+        "@github/copilot-win32-arm64": "1.0.23",
+        "@github/copilot-win32-x64": "1.0.23"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.11.tgz",
-      "integrity": "sha512-wdKimjtbsVeXqMqQSnGpGBPFEYHljxXNuWeH8EIJTNRgFpAsimcivsFgql3Twq4YOp0AxfsH36icG4IEen30mA==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.23.tgz",
+      "integrity": "sha512-jLPa6koJLKp1fNI2k9Tetj4h6Tht6dXHM8MVZQtZ+ap8Z03OBAXpHIVvBaI+qSbRkP6BE74mevIG6nUhD7FZLw==",
       "cpu": [
         "arm64"
       ],
@@ -519,9 +516,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.11.tgz",
-      "integrity": "sha512-VeuPv8rzBVGBB8uDwMEhcHBpldoKaq26yZ5YQm+G9Ka5QIF+1DMah8ZNRMVsTeNKkb1ji9G8vcuCsaPbnG3fKg==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.23.tgz",
+      "integrity": "sha512-CBNjzo/qb4w8TDDObPIkP9njen8PC+MJhQTHGq2lSwbSU4UOIKEbkzrU1ZxLaLrUR8H5i5dorsnty+XZFAzcyg==",
       "cpu": [
         "x64"
       ],
@@ -535,9 +532,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.11.tgz",
-      "integrity": "sha512-/d8p6RlFYKj1Va2hekFIcYNMHWagcEkaxgcllUNXSyQLnmEtXUkaWtz62VKGWE+n/UMkEwCB6vI2xEwPTlUNBQ==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.23.tgz",
+      "integrity": "sha512-XQ8x8xoNyhUErfxTCuYDWFMEjl2GZCbVit87tcO+dJ4rJBKokuLRIR1UUTVhOB3pe/F3d/Dl9D7ytEs3hTIw7A==",
       "cpu": [
         "arm64"
       ],
@@ -551,9 +548,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.11.tgz",
-      "integrity": "sha512-UujTRO3xkPFC1CybchBbCnaTEAG6JrH0etIst07JvfekMWgvRxbiCHQPpDPSzBCPiBcGu0gba0/IT+vUCORuIw==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.23.tgz",
+      "integrity": "sha512-OoPZ/Z8fVCam/IDyjhhCn+qj7rnQKS7987pyCfsWcrKoCiX9NB3pzXaoGBXQfndcu9TmH3qi+DJoaO+aJaLHfg==",
       "cpu": [
         "x64"
       ],
@@ -567,12 +564,12 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.0.tgz",
-      "integrity": "sha512-fCEpD9W9xqcaCAJmatyNQ1PkET9P9liK2P4Vk0raDFoMXcvpIdqewa5JQeKtWCBUsN/HCz7ExkkFP8peQuo+DA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.2.tgz",
+      "integrity": "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.10",
+        "@github/copilot": "^1.0.21",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -581,9 +578,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.11.tgz",
-      "integrity": "sha512-EOW8HUM+EmnHEZEa+iUMl4pP1+2eZUk2XCbynYiMehwX9sidc4BxEHp2RuxADSzFPTieQEWzgjQmHWrtet8pQg==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.23.tgz",
+      "integrity": "sha512-7mwtEwhES1V4b4u3Rg5bztaNyyGvEP3WnIuPqleiXDmot2ofOA4Zj5HemSsTbxTCeJc7jL7xRxyjX851xKiW2w==",
       "cpu": [
         "arm64"
       ],
@@ -597,9 +594,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.11.tgz",
-      "integrity": "sha512-fKGkSNamzs3h9AbmswNvPYJBORCb2Y8CbusijU3C7fT3ohvqnHJwKo5iHhJXLOKZNOpFZgq9YKha410u9sIs6Q==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.23.tgz",
+      "integrity": "sha512-ZOhnwGFtx1cb4a/AOpQS/gmEBkv5rS9YtO3S+e/0etT1+q+A2RRcDh9ahtM4d7P7v4Tb+Ws64MSXOrwsXvvXhA==",
       "cpu": [
         "x64"
       ],
@@ -649,9 +646,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -668,9 +665,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -678,9 +675,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
       "cpu": [
         "arm64"
       ],
@@ -695,9 +692,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
       "cpu": [
         "arm64"
       ],
@@ -712,9 +709,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
       "cpu": [
         "x64"
       ],
@@ -729,9 +726,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
       "cpu": [
         "x64"
       ],
@@ -746,9 +743,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
       "cpu": [
         "arm"
       ],
@@ -763,9 +760,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
       "cpu": [
         "arm64"
       ],
@@ -780,9 +777,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
       "cpu": [
         "arm64"
       ],
@@ -797,9 +794,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
       "cpu": [
         "ppc64"
       ],
@@ -814,9 +811,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
       "cpu": [
         "s390x"
       ],
@@ -831,9 +828,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
       "cpu": [
         "x64"
       ],
@@ -848,9 +845,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
       "cpu": [
         "x64"
       ],
@@ -865,9 +862,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
       "cpu": [
         "arm64"
       ],
@@ -882,9 +879,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
       "cpu": [
         "wasm32"
       ],
@@ -892,16 +889,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
       "cpu": [
         "arm64"
       ],
@@ -916,9 +915,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
       "cpu": [
         "x64"
       ],
@@ -933,23 +932,23 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@slack/bolt": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.6.0.tgz",
-      "integrity": "sha512-xPgfUs2+OXSugz54Ky07pA890+Qydk22SYToi8uGpXeHSt1JWwFJkRyd/9Vlg5I1AdfdpGXExDpwnbuN9Q/2dQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.7.0.tgz",
+      "integrity": "sha512-Xpf+gKegNvkHpft1z4YiuqZdciJ3tUp1bIRQxylW30Ovf+hzjb0M1zTHVtJsRw9jsjPxHTPoyanEXVvG6qVE1g==",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4.0.0",
-        "@slack/oauth": "^3.0.4",
-        "@slack/socket-mode": "^2.0.5",
-        "@slack/types": "^2.18.0",
-        "@slack/web-api": "^7.12.0",
+        "@slack/logger": "^4.0.1",
+        "@slack/oauth": "^3.0.5",
+        "@slack/socket-mode": "^2.0.6",
+        "@slack/types": "^2.20.1",
+        "@slack/web-api": "^7.15.0",
         "axios": "^1.12.0",
         "express": "^5.0.0",
         "path-to-regexp": "^8.1.0",
@@ -965,12 +964,12 @@
       }
     },
     "node_modules/@slack/logger": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
-      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+      "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": ">=18.0.0"
+        "@types/node": ">=18"
       },
       "engines": {
         "node": ">= 18",
@@ -978,13 +977,13 @@
       }
     },
     "node_modules/@slack/oauth": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-3.0.4.tgz",
-      "integrity": "sha512-+8H0g7mbrHndEUbYCP7uYyBCbwqmm3E6Mo3nfsDvZZW74zKk1ochfH/fWSvGInYNCVvaBUbg3RZBbTp0j8yJCg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-3.0.5.tgz",
+      "integrity": "sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A==",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4",
-        "@slack/web-api": "^7.10.0",
+        "@slack/logger": "^4.0.1",
+        "@slack/web-api": "^7.15.0",
         "@types/jsonwebtoken": "^9",
         "@types/node": ">=18",
         "jsonwebtoken": "^9"
@@ -995,13 +994,13 @@
       }
     },
     "node_modules/@slack/socket-mode": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.5.tgz",
-      "integrity": "sha512-VaapvmrAifeFLAFaDPfGhEwwunTKsI6bQhYzxRXw7BSujZUae5sANO76WqlVsLXuhVtCVrBWPiS2snAQR2RHJQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.6.tgz",
+      "integrity": "sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ==",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4",
-        "@slack/web-api": "^7.10.0",
+        "@slack/logger": "^4.0.1",
+        "@slack/web-api": "^7.15.0",
         "@types/node": ">=18",
         "@types/ws": "^8",
         "eventemitter3": "^5",
@@ -1013,9 +1012,9 @@
       }
     },
     "node_modules/@slack/types": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.0.tgz",
-      "integrity": "sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.1.tgz",
+      "integrity": "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==",
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0",
@@ -1023,14 +1022,14 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.14.1.tgz",
-      "integrity": "sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.0.tgz",
+      "integrity": "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4.0.0",
-        "@slack/types": "^2.20.0",
-        "@types/node": ">=18.0.0",
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.20.1",
+        "@types/node": ">=18",
         "@types/retry": "0.12.0",
         "axios": "^1.13.5",
         "eventemitter3": "^5.0.1",
@@ -1234,16 +1233,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1252,13 +1251,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1279,9 +1278,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1292,13 +1291,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1306,14 +1305,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1322,9 +1321,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1332,13 +1331,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1376,14 +1375,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/base64-js": {
@@ -2936,9 +2935,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "dev": true,
       "funding": [
         {
@@ -3005,10 +3004,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -3107,14 +3109,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3123,21 +3125,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/router": {
@@ -3466,14 +3468,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3608,16 +3610,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
+        "rolldown": "1.0.0-rc.15",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -3635,7 +3637,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -3686,19 +3688,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -3726,10 +3728,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3751,6 +3755,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@github/copilot-sdk": "^0.2.0",
+    "@github/copilot-sdk": "^0.2.2",
     "@mattermost/client": "^11.5.0",
     "@mattermost/types": "^11.5.0",
-    "@slack/bolt": "^4.6.0",
+    "@slack/bolt": "^4.7.0",
     "better-sqlite3": "^12.6.2",
     "cron": "^4.4.0",
     "cronstrue": "^3.14.0",
@@ -57,6 +57,6 @@
     "@types/better-sqlite3": "^7.6.12",
     "@types/ws": "^8.5.14",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.4"
   }
 }

--- a/src/core/bridge.ts
+++ b/src/core/bridge.ts
@@ -86,6 +86,7 @@ export class CopilotBridge {
     onUserInputRequest?: UserInputHandler;
     systemMessage?: SystemMessageConfig;
     customAgents?: CustomAgentConfig[];
+    enableConfigDiscovery?: boolean;
     tools?: Tool[];
     hooks?: SessionHooks;
     infiniteSessions?: boolean;
@@ -107,6 +108,7 @@ export class CopilotBridge {
       streaming: true,
       systemMessage: opts.systemMessage,
       customAgents: opts.customAgents,
+      enableConfigDiscovery: opts.enableConfigDiscovery,
       tools: opts.tools,
       hooks: opts.hooks,
       ...(opts.infiniteSessions ? { infiniteSessions: { enabled: true } } : { infiniteSessions: { enabled: false } }),
@@ -122,6 +124,7 @@ export class CopilotBridge {
       onUserInputRequest?: UserInputHandler;
       systemMessage?: SystemMessageConfig;
       customAgents?: CustomAgentConfig[];
+      enableConfigDiscovery?: boolean;
       configDir?: string;
       workingDirectory?: string;
       provider?: SDKProviderConfig;
@@ -146,6 +149,7 @@ export class CopilotBridge {
       streaming: true,
       systemMessage: opts?.systemMessage,
       customAgents: opts?.customAgents,
+      enableConfigDiscovery: opts?.enableConfigDiscovery,
       configDir: opts?.configDir,
       workingDirectory: opts?.workingDirectory,
       provider: opts?.provider,

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -417,10 +417,23 @@ function buildCustomAgents(workingDirectory: string): { name: string; prompt: st
   if (definitions.size === 0) return [];
   const agents: { name: string; prompt: string; description?: string }[] = [];
   for (const [name, def] of definitions) {
-    agents.push({ name, prompt: def.content });
+    const description = extractFrontmatterField(def.content, 'description');
+    agents.push({ name, prompt: def.content, ...(description ? { description } : {}) });
   }
   log.debug(`Built ${agents.length} custom agent(s) for SDK: ${agents.map(a => a.name).join(', ')}`);
   return agents;
+}
+
+/** Extract a field value from YAML frontmatter. */
+function extractFrontmatterField(content: string, field: string): string | undefined {
+  const lines = content.split('\n');
+  if (lines[0]?.trim() !== '---') return undefined;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') break;
+    const match = lines[i].match(new RegExp(`^${field}:\\s*(.+)`, 'i'));
+    if (match) return match[1].trim().replace(/^["']|["']$/g, '');
+  }
+  return undefined;
 }
 
 /** Extract a succinct summary from plan content (first heading + first body line, ~150 chars max). */
@@ -1150,8 +1163,8 @@ export class SessionManager {
         }
       });
     } catch (err: any) {
-      const msg = String(err?.message ?? err);
-      if (agent && msg.includes('not found') && msg.toLowerCase().includes('agent')) {
+      const msg = String(err?.message ?? err).toLowerCase();
+      if (agent && msg.includes('not found') && msg.includes('agent')) {
         // Agent not in current session — save pref and create a new session with config discovery
         log.info(`Agent "${agent}" not in current session, creating new session with config discovery`);
         try { await setChannelPrefs(channelId, { agent }); }
@@ -1706,10 +1719,10 @@ export class SessionManager {
       usedModel = result.usedModel;
       didFallback = result.didFallback;
     } catch (err: any) {
-      const msg = String(err?.message ?? err);
+      const msg = String(err?.message ?? err).toLowerCase();
 
       // Agent not found — clear the pref and retry without the agent
-      if (prefs.agent && msg.includes('not found') && msg.toLowerCase().includes('agent')) {
+      if (prefs.agent && msg.includes('not found') && msg.includes('agent')) {
         log.warn(`Agent "${prefs.agent}" not found for channel ${channelId}, falling back to default`);
         prefs.agent = null;
         try { await setChannelPrefs(channelId, { agent: null }); }
@@ -1748,10 +1761,10 @@ export class SessionManager {
       } else if (providerName && sdkProvider) {
         // Enhance error message with BYOK context (only when provider actually resolved)
         const provConfig = getConfig().providers?.[providerName];
-        if (msg.includes('ECONNREFUSED') || msg.includes('ENOTFOUND') || msg.includes('fetch failed')) {
+        if (msg.includes('econnrefused') || msg.includes('enotfound') || msg.includes('fetch failed')) {
           throw new Error(`Provider "${providerName}" is unreachable at ${provConfig?.baseUrl ?? 'unknown URL'}. Check that the service is running.`);
         }
-        if (msg.includes('401') || msg.includes('403') || msg.includes('Unauthorized') || msg.includes('Forbidden')) {
+        if (msg.includes('401') || msg.includes('403') || msg.includes('unauthorized') || msg.includes('forbidden')) {
           throw new Error(`Provider "${providerName}" rejected authentication. Check your API key configuration.`);
         }
         if (msg.includes('404') || msg.includes('model not found') || msg.includes('does not exist')) {

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -308,17 +308,10 @@ export function extractCommandPatterns(input: unknown): string[] {
 }
 
 /**
- * Discover skill directories NOT covered by the SDK's enableConfigDiscovery.
- * The SDK auto-discovers workspace-level skills (<workspace>/.github/skills/, etc.)
- * so we only need to supply sources it doesn't scan:
- * - ~/.copilot/skills/ (user-level)
- * - ~/.agents/skills/ (user-level)
- * - Plugin skills from ~/.copilot/installed-plugins/ (lowest priority)
- *
- * Per CLI spec, skills use first-found-wins dedup by name.
- * Plugin skills are appended last so user/workspace skills take precedence.
+ * Discover ALL skill directories (user, plugin, AND workspace).
+ * Used by getSkillInfo() for display in /skills listing.
  */
-function discoverSkillDirectories(_workingDirectory: string): string[] {
+function discoverAllSkillDirectories(workingDirectory: string): string[] {
   const home = process.env.HOME;
   const roots: string[] = [];
 
@@ -327,6 +320,10 @@ function discoverSkillDirectories(_workingDirectory: string): string[] {
     roots.push(path.join(home, '.copilot', 'skills'));
     roots.push(path.join(home, '.agents', 'skills'));
   }
+  // Project-level skills (standard)
+  roots.push(path.join(workingDirectory, '.github', 'skills'));
+  // Project-level skills (legacy)
+  roots.push(path.join(workingDirectory, '.agents', 'skills'));
 
   // Plugin skills (lowest priority — appended last so earlier sources win)
   if (home) {
@@ -350,6 +347,49 @@ function discoverSkillDirectories(_workingDirectory: string): string[] {
     }
   }
 
+  return resolveSkillRoots(roots);
+}
+
+/**
+ * Discover skill directories NOT covered by the SDK's enableConfigDiscovery.
+ * The SDK auto-discovers workspace-level skills (<workspace>/.github/skills/, etc.)
+ * so we only supply sources it doesn't scan: user-level and plugin skills.
+ * Callers that set enableConfigDiscovery: true should use this to avoid duplicates.
+ */
+function discoverExtraSkillDirectories(): string[] {
+  const home = process.env.HOME;
+  if (!home) return [];
+  const roots: string[] = [];
+
+  // User-level skills
+  roots.push(path.join(home, '.copilot', 'skills'));
+  roots.push(path.join(home, '.agents', 'skills'));
+
+  // Plugin skills
+  const pluginsDir = path.join(home, '.copilot', 'installed-plugins');
+  if (fs.existsSync(pluginsDir)) {
+    const walk = (dir: string, depth: number) => {
+      if (depth > 3) return;
+      try {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          if (!entry.isDirectory()) continue;
+          const full = path.join(dir, entry.name);
+          if (entry.name === 'skills') {
+            roots.push(full);
+          } else {
+            walk(full, depth + 1);
+          }
+        }
+      } catch (err) { log.debug('Skill dir walk permission error:', err); }
+    };
+    walk(pluginsDir, 0);
+  }
+
+  return resolveSkillRoots(roots);
+}
+
+/** Expand skill roots into individual skill directories. */
+function resolveSkillRoots(roots: string[]): string[] {
   const dirs: string[] = [];
   for (const skillsRoot of roots) {
     if (!fs.existsSync(skillsRoot)) continue;
@@ -590,7 +630,7 @@ export class SessionManager {
   /** Get skill info for a channel — discovers skills and reads their descriptions from SKILL.md frontmatter. */
   async getSkillInfo(channelId: string): Promise<{ name: string; description: string; source: string; pending?: boolean; disabled?: boolean }[]> {
     const workingDirectory = await this.resolveWorkingDirectory(channelId);
-    const dirs = discoverSkillDirectories(workingDirectory);
+    const dirs = discoverAllSkillDirectories(workingDirectory);
     const sessionDirs = this.sessionSkillDirs.get(channelId);
     const prefs = await getChannelPrefs(channelId);
     const disabledSet = new Set(prefs?.disabledSkills ?? []);
@@ -1588,7 +1628,7 @@ export class SessionManager {
     const defaultConfigDir = process.env.HOME ? `${process.env.HOME}/.copilot` : undefined;
 
     const reasoningEffort = prefs.reasoningEffort as 'low' | 'medium' | 'high' | 'xhigh' | undefined;
-    const skillDirectories = discoverSkillDirectories(workingDirectory);
+    const skillDirectories = discoverExtraSkillDirectories();
     const customTools = await this.buildCustomTools(channelId);
     const disabledSkills = prefs.disabledSkills?.length ? prefs.disabledSkills : undefined;
 
@@ -1765,7 +1805,7 @@ export class SessionManager {
     const workingDirectory = await this.resolveWorkingDirectory(channelId);
     const defaultConfigDir = process.env.HOME ? `${process.env.HOME}/.copilot` : undefined;
     const reasoningEffort = prefs.reasoningEffort as 'low' | 'medium' | 'high' | 'xhigh' | undefined;
-    const skillDirectories = discoverSkillDirectories(workingDirectory);
+    const skillDirectories = discoverExtraSkillDirectories();
     const customTools = await this.buildCustomTools(channelId);
     const disabledSkills = prefs.disabledSkills?.length ? prefs.disabledSkills : undefined;
 
@@ -1879,7 +1919,7 @@ export class SessionManager {
     }
 
     const defaultConfigDir = process.env.HOME ? `${process.env.HOME}/.copilot` : undefined;
-    const skillDirectories = discoverSkillDirectories(targetWorkspace);
+    const skillDirectories = discoverExtraSkillDirectories();
     const hooks = await this.resolveHooks(targetWorkspace);
 
     // Build ephemeral permission handler
@@ -1895,6 +1935,7 @@ export class SessionManager {
         this.bridge.createSession({
           workingDirectory: targetWorkspace,
           configDir: defaultConfigDir,
+          enableConfigDiscovery: true,
           mcpServers: this.resolveMcpServers(targetWorkspace),
           skillDirectories: skillDirectories.length > 0 ? skillDirectories : undefined,
           onPermissionRequest: ephemeralPermissionHandler,

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1090,13 +1090,26 @@ export class SessionManager {
 
   /** Switch the agent for a channel's session. */
   async switchAgent(channelId: string, agent: string | null): Promise<void> {
-    await this.withSessionRetry(channelId, async (sid) => {
-      if (agent) {
-        await this.bridge.selectAgent(sid, agent);
-      } else {
-        await this.bridge.deselectAgent(sid);
+    try {
+      await this.withSessionRetry(channelId, async (sid) => {
+        if (agent) {
+          await this.bridge.selectAgent(sid, agent);
+        } else {
+          await this.bridge.deselectAgent(sid);
+        }
+      });
+    } catch (err: any) {
+      const msg = String(err?.message ?? err);
+      if (agent && msg.includes('not found') && msg.toLowerCase().includes('agent')) {
+        // Agent not in current session — save pref and create a new session with config discovery
+        log.info(`Agent "${agent}" not in current session, creating new session with config discovery`);
+        try { await setChannelPrefs(channelId, { agent }); }
+        catch (e) { log.warn('Failed to persist agent preference:', e); }
+        await this.newSession(channelId);
+        return;
       }
-    });
+      throw err;
+    }
     try { await setChannelPrefs(channelId, { agent }); }
     catch (e) { log.warn('Agent switched but failed to persist preference:', e); }
   }
@@ -1607,6 +1620,7 @@ export class SessionManager {
           configDir: defaultConfigDir,
           reasoningEffort: reasoningEffort ?? undefined,
           agent: prefs.agent ?? undefined,
+          enableConfigDiscovery: true,
           mcpServers: resolvedMcpServers,
           skillDirectories: skillDirectories.length > 0 ? skillDirectories : undefined,
           disabledSkills,
@@ -1624,6 +1638,7 @@ export class SessionManager {
     let session: any;
     let usedModel: string;
     let didFallback: boolean;
+    let agentFallback = false;
 
     try {
       const result = await tryWithFallback(
@@ -1637,9 +1652,46 @@ export class SessionManager {
       usedModel = result.usedModel;
       didFallback = result.didFallback;
     } catch (err: any) {
-      // Enhance error message with BYOK context (only when provider actually resolved)
-      if (providerName && sdkProvider) {
-        const msg = String(err?.message ?? err);
+      const msg = String(err?.message ?? err);
+
+      // Agent not found — clear the pref and retry without the agent
+      if (prefs.agent && msg.includes('not found') && msg.toLowerCase().includes('agent')) {
+        log.warn(`Agent "${prefs.agent}" not found for channel ${channelId}, falling back to default`);
+        prefs.agent = null;
+        try { await setChannelPrefs(channelId, { agent: null }); }
+        catch (e) { log.warn('Failed to clear agent pref:', e); }
+
+        // Rebuild createWithModel without the agent
+        const createWithModelNoAgent = async (model: string) => {
+          return withWorkspaceEnv(workingDirectory, () =>
+            this.bridge.createSession({
+              model,
+              provider: sdkProvider || undefined,
+              workingDirectory,
+              configDir: defaultConfigDir,
+              reasoningEffort: reasoningEffort ?? undefined,
+              enableConfigDiscovery: true,
+              mcpServers: resolvedMcpServers,
+              skillDirectories: skillDirectories.length > 0 ? skillDirectories : undefined,
+              disabledSkills,
+              onPermissionRequest: (request, invocation) => this.handlePermissionRequest(channelId, request, invocation),
+              onUserInputRequest: (request, invocation) => this.handleUserInputRequest(channelId, request, invocation),
+              tools: customTools.length > 0 ? customTools : undefined,
+              hooks,
+              infiniteSessions: getConfig().infiniteSessions,
+              systemMessage: this.buildSystemMessage(),
+            })
+          );
+        };
+        const result = await tryWithFallback(
+          prefs.model, availableModels, configFallbacks, createWithModelNoAgent, byokPrefixes,
+        );
+        session = result.result;
+        usedModel = result.usedModel;
+        didFallback = result.didFallback;
+        agentFallback = true;
+      } else if (providerName && sdkProvider) {
+        // Enhance error message with BYOK context (only when provider actually resolved)
         const provConfig = getConfig().providers?.[providerName];
         if (msg.includes('ECONNREFUSED') || msg.includes('ENOTFOUND') || msg.includes('fetch failed')) {
           throw new Error(`Provider "${providerName}" is unreachable at ${provConfig?.baseUrl ?? 'unknown URL'}. Check that the service is running.`);
@@ -1651,8 +1703,9 @@ export class SessionManager {
           throw new Error(`Model "${prefs.model}" not found on provider "${providerName}". Check the model ID in your config.`);
         }
         throw new Error(`Provider "${providerName}" error: ${msg}`);
+      } else {
+        throw err;
       }
-      throw err;
     }
 
     this.sessionMcpServers.set(channelId, new Set(Object.keys(resolvedMcpServers)));
@@ -1668,6 +1721,15 @@ export class SessionManager {
         type: 'assistant.message',
         data: {
           content: `⚠️ Model \`${prefs.model}\` is unavailable. Switched to \`${usedModel}\`.`,
+        },
+      });
+    }
+
+    if (agentFallback) {
+      this.eventHandler?.(session.sessionId, channelId, {
+        type: 'assistant.message',
+        data: {
+          content: `⚠️ Agent not found. Reverted to default. Use \`/agent\` to select a new agent.`,
         },
       });
     }
@@ -1717,6 +1779,7 @@ export class SessionManager {
         provider: sdkProvider || undefined,
         reasoningEffort: reasoningEffort ?? undefined,
         agent: prefs.agent ?? undefined,
+        enableConfigDiscovery: true,
         mcpServers,
         skillDirectories: skillDirectories.length > 0 ? skillDirectories : undefined,
         disabledSkills,

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -308,17 +308,17 @@ export function extractCommandPatterns(input: unknown): string[] {
 }
 
 /**
- * Discover skill directories following Copilot CLI conventions:
+ * Discover skill directories NOT covered by the SDK's enableConfigDiscovery.
+ * The SDK auto-discovers workspace-level skills (<workspace>/.github/skills/, etc.)
+ * so we only need to supply sources it doesn't scan:
  * - ~/.copilot/skills/ (user-level)
  * - ~/.agents/skills/ (user-level)
- * - <workspace>/.github/skills/ (project-level)
- * - <workspace>/.agents/skills/ (project-level)
  * - Plugin skills from ~/.copilot/installed-plugins/ (lowest priority)
  *
  * Per CLI spec, skills use first-found-wins dedup by name.
  * Plugin skills are appended last so user/workspace skills take precedence.
  */
-function discoverSkillDirectories(workingDirectory: string): string[] {
+function discoverSkillDirectories(_workingDirectory: string): string[] {
   const home = process.env.HOME;
   const roots: string[] = [];
 
@@ -327,10 +327,6 @@ function discoverSkillDirectories(workingDirectory: string): string[] {
     roots.push(path.join(home, '.copilot', 'skills'));
     roots.push(path.join(home, '.agents', 'skills'));
   }
-  // Project-level skills (standard)
-  roots.push(path.join(workingDirectory, '.github', 'skills'));
-  // Project-level skills (legacy)
-  roots.push(path.join(workingDirectory, '.agents', 'skills'));
 
   // Plugin skills (lowest priority — appended last so earlier sources win)
   if (home) {
@@ -370,6 +366,21 @@ function discoverSkillDirectories(workingDirectory: string): string[] {
     log.info(`Discovered ${dirs.length} skill(s): ${dirs.map(d => path.basename(d)).join(', ')}`);
   }
   return dirs;
+}
+
+/**
+ * Convert discovered agent definitions to SDK CustomAgentConfig[].
+ * This lets the SDK resolve plugin/user agents by name (they aren't on the SDK's search path).
+ */
+function buildCustomAgents(workingDirectory: string): { name: string; prompt: string; description?: string }[] {
+  const definitions = discoverAgentDefinitions(workingDirectory);
+  if (definitions.size === 0) return [];
+  const agents: { name: string; prompt: string; description?: string }[] = [];
+  for (const [name, def] of definitions) {
+    agents.push({ name, prompt: def.content });
+  }
+  log.debug(`Built ${agents.length} custom agent(s) for SDK: ${agents.map(a => a.name).join(', ')}`);
+  return agents;
 }
 
 /** Extract a succinct summary from plan content (first heading + first body line, ~150 chars max). */
@@ -1611,6 +1622,8 @@ export class SessionManager {
       log.debug(`Hooks resolved for session create: ${Object.keys(hooks).join(', ')}`);
     }
 
+    const customAgents = buildCustomAgents(workingDirectory);
+
     const createWithModel = async (model: string) => {
       return withWorkspaceEnv(workingDirectory, () =>
         this.bridge.createSession({
@@ -1626,6 +1639,7 @@ export class SessionManager {
           disabledSkills,
           onPermissionRequest: (request, invocation) => this.handlePermissionRequest(channelId, request, invocation),
           onUserInputRequest: (request, invocation) => this.handleUserInputRequest(channelId, request, invocation),
+          customAgents: customAgents.length > 0 ? customAgents : undefined,
           tools: customTools.length > 0 ? customTools : undefined,
           hooks,
           infiniteSessions: getConfig().infiniteSessions,
@@ -1676,6 +1690,7 @@ export class SessionManager {
               disabledSkills,
               onPermissionRequest: (request, invocation) => this.handlePermissionRequest(channelId, request, invocation),
               onUserInputRequest: (request, invocation) => this.handleUserInputRequest(channelId, request, invocation),
+              customAgents: customAgents.length > 0 ? customAgents : undefined,
               tools: customTools.length > 0 ? customTools : undefined,
               hooks,
               infiniteSessions: getConfig().infiniteSessions,
@@ -1761,6 +1776,8 @@ export class SessionManager {
       log.debug(`Hooks resolved for session resume: ${Object.keys(hooks).join(', ')}`);
     }
 
+    const customAgents = buildCustomAgents(workingDirectory);
+
     // Resolve BYOK provider for resume
     const providerName = prefs.provider ?? null;
     let sdkProvider = providerName
@@ -1783,6 +1800,7 @@ export class SessionManager {
         mcpServers,
         skillDirectories: skillDirectories.length > 0 ? skillDirectories : undefined,
         disabledSkills,
+        customAgents: customAgents.length > 0 ? customAgents : undefined,
         tools: customTools.length > 0 ? customTools : undefined,
         hooks,
         infiniteSessions: getConfig().infiniteSessions,


### PR DESCRIPTION
## Changes

### Dependency Updates
 0.2.2
 4.7.0
 4.1.4

### Fix: Plugin Agent Resolution
The SDK couldn't find plugin-sourced agents (e.g., "anvil" from `~/.copilot/installed-plugins/`) because we only passed the agent name, not the definition content. Now `customAgents` is built from all discovered agent definitions (plugin, user, workspace) and passed to `createSession`/`resumeSession`, so the SDK can resolve them.

### Fix: Remove Duplicative Skill Discovery
The SDK's `enableConfigDiscovery` already discovers workspace-level skills (`.github/skills/`, `.agents/skills/`). Our manual discovery was passing the same directories, causing redundant loading. Split into:
- ` user-level + plugin sources only (for SDK sessions)discoverExtraSkillDirectories()` 
- ` full discovery including workspace (for `/skills` display)discoverAllSkillDirectories()` 
- Added `enableConfigDiscovery: true` to inter-agent ephemeral sessions (was missing)

### Testing
- 683 tests pass
- Type-check clean
- Verified plugin agent (`anvil`) resolves correctly after bridge restart