### PR TITLE
fix: support @github/copilot-sdk@0.3.0 and CLI >= 1.0.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@chrisromp/copilot-bridge",
       "version": "0.13.0",
       "dependencies": {
-        "@github/copilot-sdk": "^0.2.2",
+        "@github/copilot": "^1.0.36",
+        "@github/copilot-sdk": "^0.3.0",
         "@mattermost/client": "^11.5.0",
         "@mattermost/types": "^11.5.0",
         "@slack/bolt": "^4.7.0",
@@ -483,26 +484,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.23.tgz",
-      "integrity": "sha512-YUx8ksTEy8LjZ9PrYxT/LcZlDsX+nceNar1BGIiwnvtDvaf5bLSoo7ZkGKlBjK14WQ0KldWLk4K4MOBK4e1dEg==",
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.36.tgz",
+      "integrity": "sha512-x0N5wLzw+tANzb+vCFYLHn3BV3qii2oyn14wC20RO7SsS8/YeBH8olvwlDLJ4PB0mL17QOiytNCdkvjvprm28w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.23",
-        "@github/copilot-darwin-x64": "1.0.23",
-        "@github/copilot-linux-arm64": "1.0.23",
-        "@github/copilot-linux-x64": "1.0.23",
-        "@github/copilot-win32-arm64": "1.0.23",
-        "@github/copilot-win32-x64": "1.0.23"
+        "@github/copilot-darwin-arm64": "1.0.36",
+        "@github/copilot-darwin-x64": "1.0.36",
+        "@github/copilot-linux-arm64": "1.0.36",
+        "@github/copilot-linux-x64": "1.0.36",
+        "@github/copilot-win32-arm64": "1.0.36",
+        "@github/copilot-win32-x64": "1.0.36"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.23.tgz",
-      "integrity": "sha512-jLPa6koJLKp1fNI2k9Tetj4h6Tht6dXHM8MVZQtZ+ap8Z03OBAXpHIVvBaI+qSbRkP6BE74mevIG6nUhD7FZLw==",
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.36.tgz",
+      "integrity": "sha512-5qkb7frTS4K/LdTDLrzKo78VR4aw/EZ6JzLz4KfmaW4UYyPiNirExDFXa/By22X0o8YMfOp4MCA2KSCAxKdgTg==",
       "cpu": [
         "arm64"
       ],
@@ -516,9 +517,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.23.tgz",
-      "integrity": "sha512-CBNjzo/qb4w8TDDObPIkP9njen8PC+MJhQTHGq2lSwbSU4UOIKEbkzrU1ZxLaLrUR8H5i5dorsnty+XZFAzcyg==",
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.36.tgz",
+      "integrity": "sha512-AdsM8QtM5QSzMLpavLREh8HALO5G+VWzGNQqIHu4f0YQC/s1cGoiwo3wsgkpxRcLGBykFc+bDX3yK3MDQ8XvSw==",
       "cpu": [
         "x64"
       ],
@@ -532,9 +533,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.23.tgz",
-      "integrity": "sha512-XQ8x8xoNyhUErfxTCuYDWFMEjl2GZCbVit87tcO+dJ4rJBKokuLRIR1UUTVhOB3pe/F3d/Dl9D7ytEs3hTIw7A==",
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.36.tgz",
+      "integrity": "sha512-n7K1I6r0ggOJ4A9uAMS11USTvn6BKtAwvrOkzEaeRK89VNUJzpTe6p0mE13ItzRe5eot9WLBQOxvXLtL9f6E+g==",
       "cpu": [
         "arm64"
       ],
@@ -548,9 +549,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.23.tgz",
-      "integrity": "sha512-OoPZ/Z8fVCam/IDyjhhCn+qj7rnQKS7987pyCfsWcrKoCiX9NB3pzXaoGBXQfndcu9TmH3qi+DJoaO+aJaLHfg==",
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.36.tgz",
+      "integrity": "sha512-wBtCdR3ITZcq07BJbkwHfwI6ayiwbH5pF1ex+Ycl4UI+Lf1vP9eQD6wJppPgsrjwFcdeWRThaYTPCRTkSGHv5g==",
       "cpu": [
         "x64"
       ],
@@ -564,12 +565,12 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.2.tgz",
-      "integrity": "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.3.0.tgz",
+      "integrity": "sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.21",
+        "@github/copilot": "^1.0.36-0",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -578,9 +579,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.23.tgz",
-      "integrity": "sha512-7mwtEwhES1V4b4u3Rg5bztaNyyGvEP3WnIuPqleiXDmot2ofOA4Zj5HemSsTbxTCeJc7jL7xRxyjX851xKiW2w==",
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.36.tgz",
+      "integrity": "sha512-0GzZUZQn07alI8BgbzK0NlR5+ta/Rd0sWmd8kbRCns7oybAIkSALy6BKVwJmVHtXUi6h4iUE8oiFhkn0spymvw==",
       "cpu": [
         "arm64"
       ],
@@ -594,9 +595,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.23.tgz",
-      "integrity": "sha512-ZOhnwGFtx1cb4a/AOpQS/gmEBkv5rS9YtO3S+e/0etT1+q+A2RRcDh9ahtM4d7P7v4Tb+Ws64MSXOrwsXvvXhA==",
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.36.tgz",
+      "integrity": "sha512-UBX9qj0McCK/SLq93XIr1i80fj3b3XmE3befVFrzxQuTeOoxLURN35vi7W+4x+4ZfsDHQpRTlJNjZw9w0fPr+Q==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@github/copilot-sdk": "^0.2.2",
+    "@github/copilot": "^1.0.36",
+    "@github/copilot-sdk": "^0.3.0",
     "@mattermost/client": "^11.5.0",
     "@mattermost/types": "^11.5.0",
     "@slack/bolt": "^4.7.0",

--- a/src/core/bridge.ts
+++ b/src/core/bridge.ts
@@ -238,16 +238,16 @@ export class CopilotBridge {
   }
 
   // Session RPC proxies (accessed via private API)
-  async getSessionMode(id: string): Promise<{ mode: string }> {
+  async getSessionMode(id: string): Promise<'interactive' | 'plan' | 'autopilot'> {
     const session = this.sessions.get(id);
     if (!session) throw new Error(`Session ${id} not active`);
     return session.rpc.mode.get();
   }
 
-  async setSessionMode(id: string, mode: 'interactive' | 'plan' | 'autopilot'): Promise<{ mode: string }> {
+  async setSessionMode(id: string, mode: 'interactive' | 'plan' | 'autopilot'): Promise<void> {
     const session = this.sessions.get(id);
     if (!session) throw new Error(`Session ${id} not active`);
-    return session.rpc.mode.set({ mode });
+    await session.rpc.mode.set({ mode });
   }
 
   async readPlan(id: string): Promise<{ exists: boolean; content: string | null; path: string | null }> {

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -573,7 +573,7 @@ export class SessionManager {
           toolInput: input.toolArgs,
           commands: [],
           resolve: (decision: any) => {
-            if (decision.kind === 'approved') {
+            if (decision.kind === 'approve-once') {
               resolve({ ...result, permissionDecision: 'allow' });
             } else {
               resolve({ ...result, permissionDecision: 'deny', permissionDecisionReason: reason });

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -982,7 +982,7 @@ export class SessionManager {
     if (queue && queue.length > 0) {
       log.info(`Auto-denying ${queue.length} pending permission(s) for channel ${channelId}`);
       for (const entry of queue) {
-        entry.resolve({ kind: 'denied-interactively-by-user' });
+        entry.resolve({ kind: 'reject' });
       }
       this.pendingPermissions.delete(channelId);
     }
@@ -1250,8 +1250,8 @@ export class SessionManager {
     const sessionId = this.channelSessions.get(channelId);
     if (sessionId) {
       try {
-        const result = await this.withSessionRetry(channelId, (sid) => this.bridge.getSessionMode(sid), false);
-        return result.mode;
+        const mode = await this.withSessionRetry(channelId, (sid) => this.bridge.getSessionMode(sid), false);
+        return mode;
       } catch (err) { log.debug(`getSessionMode(${channelId.slice(0, 8)}) failed, falling through to prefs:`, err); }
     }
     const prefs = await getChannelPrefs(channelId);
@@ -1260,10 +1260,10 @@ export class SessionManager {
 
   /** Set the session mode (interactive, plan, autopilot). Persists to channel prefs. Does not change yolo/permission state. */
   async setSessionMode(channelId: string, mode: 'interactive' | 'plan' | 'autopilot'): Promise<string> {
-    const result = await this.withSessionRetry(channelId, (sid) => this.bridge.setSessionMode(sid, mode));
-    try { await setChannelPrefs(channelId, { sessionMode: result.mode }); }
+    await this.withSessionRetry(channelId, (sid) => this.bridge.setSessionMode(sid, mode));
+    try { await setChannelPrefs(channelId, { sessionMode: mode }); }
     catch (e) { log.warn('Session mode set but failed to persist preference:', e); }
-    return result.mode;
+    return mode;
   }
 
   /** Read the plan.md file from the session workspace. */
@@ -1344,7 +1344,7 @@ export class SessionManager {
     try {
       session = await this.bridge.createSession({
         ...(model ? { model } : {}),
-        onPermissionRequest: async () => ({ kind: 'denied-interactively-by-user' as const }),
+        onPermissionRequest: async () => ({ kind: 'reject' as const }),
         systemMessage: { content: 'You are a concise summarizer. Respond with only the summary, no preamble.' },
       });
 
@@ -1398,8 +1398,8 @@ export class SessionManager {
 
     // Resolve the permission first — don't let persistence failures block the SDK callback
     pending.resolve(allow
-      ? { kind: 'approved' }
-      : { kind: 'denied-interactively-by-user' });
+      ? { kind: 'approve-once' }
+      : { kind: 'reject' });
 
     if (remember && !pending.fromHook) {
       const action = allow ? 'allow' : 'deny';
@@ -2106,14 +2106,14 @@ export class SessionManager {
 
       // 1. Hardcoded safety denies — always enforced
       if (isHardDeny(reqKind, reqCommand)) {
-        return { kind: 'denied-by-rules' };
+        return { kind: 'reject' };
       }
 
       // 2. Caller's explicit denies — checked before auto-approve
       if (opts.denyTools && opts.denyTools.length > 0) {
         const toolName = (request as any).toolName ?? (request as any).tool_name ?? (request as any).name ?? reqKind;
         if (opts.denyTools.includes(toolName)) {
-          return { kind: 'denied-by-rules' };
+          return { kind: 'reject' };
         }
       }
 
@@ -2121,7 +2121,7 @@ export class SessionManager {
       if (reqKind === 'custom-tool') {
         const reqToolName = (request as any).toolName;
         if (BRIDGE_CUSTOM_TOOLS.includes(reqToolName)) {
-          return { kind: 'approved' };
+          return { kind: 'approve-once' };
         }
       }
 
@@ -2132,7 +2132,7 @@ export class SessionManager {
           // Verify caller has this permission
           const callerResult = await checkPermission(opts.callerChannelId, toolName, '*');
           if (callerResult === 'allow') {
-            return { kind: 'approved' };
+            return { kind: 'approve-once' };
           }
         }
       }
@@ -2142,21 +2142,21 @@ export class SessionManager {
       const targetScope = `bot:${opts.targetBot}`;
       const toolName = (request as any).toolName ?? (request as any).tool_name ?? (request as any).name ?? reqKind;
       const storedResult = await checkPermission(targetScope, toolName, '*');
-      if (storedResult === 'allow') return { kind: 'approved' };
-      if (storedResult === 'deny') return { kind: 'denied-by-rules' };
+      if (storedResult === 'allow') return { kind: 'approve-once' };
+      if (storedResult === 'deny') return { kind: 'reject' };
 
       // 6. Caller channel's stored rules (merged — supplement target)
       const callerResult = await checkPermission(opts.callerChannelId, toolName, '*');
-      if (callerResult === 'allow') return { kind: 'approved' };
+      if (callerResult === 'allow') return { kind: 'approve-once' };
 
       // 7. Autopilot: approve remaining if enabled
       if (opts.autopilot) {
-        return { kind: 'approved' };
+        return { kind: 'approve-once' };
       }
 
       // 8. No rule matched — deny with detail (no human to ask in ephemeral sessions)
       log.warn(`Ephemeral permission denied (no rule): ${toolName} for ${opts.targetBot}`);
-      return { kind: 'denied-no-approval-rule-and-could-not-request-from-user' };
+      return { kind: 'user-not-available' };
     };
   }
 
@@ -2843,20 +2843,20 @@ export class SessionManager {
     const reqCommand = typeof (request as any).fullCommandText === 'string' ? (request as any).fullCommandText
       : typeof (request as any).command === 'string' ? (request as any).command : undefined;
     if (isHardDeny(reqKind, reqCommand)) {
-      return Promise.resolve({ kind: 'denied-by-rules' });
+      return Promise.resolve({ kind: 'reject' });
     }
 
     // Auto-approve bridge custom tools (they enforce their own workspace boundaries)
     if (reqKind === 'custom-tool') {
       const reqToolName = (request as any).toolName;
       if (BRIDGE_CUSTOM_TOOLS.includes(reqToolName)) {
-        return Promise.resolve({ kind: 'approved' });
+        return Promise.resolve({ kind: 'approve-once' });
       }
     }
 
     // Autopilot mode: allow everything (after safety checks)
     if (prefs.permissionMode === 'autopilot') {
-      return Promise.resolve({ kind: 'approved' });
+      return Promise.resolve({ kind: 'approve-once' });
     }
 
     // Check config-level permission rules first (CLI-compatible syntax)
@@ -2866,10 +2866,10 @@ export class SessionManager {
     const workspaceAllowPaths = await getWorkspaceAllowPaths(botName, config.platform);
     const configResult = evaluateConfigPermissions(request as any, resolvedDir, workspaceAllowPaths, isBotAdmin(config.platform, botName));
     if (configResult === 'allow') {
-      return Promise.resolve({ kind: 'approved' });
+      return Promise.resolve({ kind: 'approve-once' });
     }
     if (configResult === 'deny') {
-      return Promise.resolve({ kind: 'denied-by-rules' });
+      return Promise.resolve({ kind: 'reject' });
     }
 
     // Check stored permission rules (SQLite, from /remember)
@@ -2888,11 +2888,11 @@ export class SessionManager {
       const serverResult = await checkPermission(channelId, `mcp:${serverName}`, '*');
       if (serverResult === 'allow') {
         log.debug(`MCP "${serverName}" auto-approved by stored rule`);
-        return Promise.resolve({ kind: 'approved' });
+        return Promise.resolve({ kind: 'approve-once' });
       }
       if (serverResult === 'deny') {
         log.debug(`MCP "${serverName}" denied by stored rule`);
-        return Promise.resolve({ kind: 'denied-by-rules' });
+        return Promise.resolve({ kind: 'reject' });
       }
     }
 
@@ -2901,16 +2901,16 @@ export class SessionManager {
       if (results.every(r => r === 'allow')) {
         const hasWrapper = commands.some(cmd => SHELL_WRAPPERS.has(cmd));
         if (!hasWrapper) {
-          return Promise.resolve({ kind: 'approved' });
+          return Promise.resolve({ kind: 'approve-once' });
         }
       }
       if (results.some(r => r === 'deny')) {
-        return Promise.resolve({ kind: 'denied-by-rules' });
+        return Promise.resolve({ kind: 'reject' });
       }
     } else {
       const result = await checkPermission(channelId, toolName, '*');
-      if (result === 'allow') return Promise.resolve({ kind: 'approved' });
-      if (result === 'deny') return Promise.resolve({ kind: 'denied-by-rules' });
+      if (result === 'allow') return Promise.resolve({ kind: 'approve-once' });
+      if (result === 'deny') return Promise.resolve({ kind: 'reject' });
     }
     } catch (err) {
       log.warn('Permission check failed, falling through to interactive:', err);
@@ -2992,7 +2992,7 @@ export class SessionManager {
     // Resolve all pending permissions (deny them on shutdown)
     for (const [, queue] of this.pendingPermissions) {
       for (const pending of queue) {
-        pending.resolve({ kind: 'denied-interactively-by-user' });
+        pending.resolve({ kind: 'reject' });
       }
     }
     this.pendingPermissions.clear();

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -982,7 +982,7 @@ export class SessionManager {
     if (queue && queue.length > 0) {
       log.info(`Auto-denying ${queue.length} pending permission(s) for channel ${channelId}`);
       for (const entry of queue) {
-        entry.resolve({ kind: 'reject' });
+        entry.resolve({ kind: 'user-not-available' });
       }
       this.pendingPermissions.delete(channelId);
     }
@@ -2989,10 +2989,10 @@ export class SessionManager {
   }
 
   async shutdown(): Promise<void> {
-    // Resolve all pending permissions (deny them on shutdown)
+    // Resolve all pending permissions (user unavailable during shutdown — not a user-driven rejection)
     for (const [, queue] of this.pendingPermissions) {
       for (const pending of queue) {
-        pending.resolve({ kind: 'reject' });
+        pending.resolve({ kind: 'user-not-available' });
       }
     }
     this.pendingPermissions.clear();

--- a/src/types.ts
+++ b/src/types.ts
@@ -255,7 +255,11 @@ export interface PendingPermission {
   hookReason?: string; // reason from hook for display in permission prompt
   toolInput: unknown;
   commands: string[]; // extracted individual commands
-  resolve: (result: { kind: 'approved' | 'denied-by-rules' | 'denied-interactively-by-user' | 'denied-no-approval-rule-and-could-not-request-from-user' }) => void;
+  resolve: (result:
+    | { kind: 'approve-once' }
+    | { kind: 'reject'; feedback?: string }
+    | { kind: 'user-not-available' }
+  ) => void;
   createdAt: number;
 }
 


### PR DESCRIPTION
## Summary

Fixes the `unexpected user permission response` error that breaks all tool calls when running `copilot-bridge` with `@github/copilot-sdk@0.3.0` (or `@github/copilot >= 1.0.25` pulled in transitively by the previous `^0.2.2` SDK constraint).

The SDK 0.3.0 / CLI 1.0.25+ release renamed the permission decision protocol kinds and changed the shape of the `session.rpc.mode.{get,set}` return types. The bridge was still emitting the old `{ kind: 'approved' | 'denied-...' }` payloads, so the CLI rejected every permission response and tool calls failed at the protocol level.

## Changes

**Dependencies (`package.json`)**
- Bump `@github/copilot-sdk` from `^0.2.2` to `^0.3.0`
- Pin `@github/copilot` to `^1.0.36` so npm does not transitively pull a CLI that is not protocol-compatible with whichever SDK happens to be installed

**Permission decision kind renames (`src/types.ts`, `src/core/session-manager.ts`)**

| Old (SDK 0.2.x) | New (SDK 0.3.0) |
|---|---|
| `approved` | `approve-once` |
| `denied-interactively-by-user` | `reject` (with optional `feedback`) |
| `denied-by-rules` | `reject` |
| `denied-no-approval-rule-and-could-not-request-from-user` | `user-not-available` |

Applied at all 25 callsites in `session-manager.ts` and the `PendingPermission.resolve` callback union in `types.ts`.

**Session mode RPC shape change (`src/core/bridge.ts`, `src/core/session-manager.ts`)**
- `session.rpc.mode.get()` now returns `SessionMode` directly (was `{ mode }`)
- `session.rpc.mode.set()` now returns `void` (was `{ mode }`)
- Updated `CopilotBridge.getSessionMode/setSessionMode` signatures and the `SessionManager` callers

## Test Evidence

- `npm run build` clean
- `npx tsc --noEmit` clean
- `npm test` -> **691 / 691 tests pass**
- Live validation: ran the patched bridge against a Mattermost instance with `@github/copilot-sdk@0.3.0` + `@github/copilot@1.0.36`. `bash`, `view`, and `grep` tool calls all succeed where they previously returned `unexpected user permission response`.

## Notes for Reviewers

- I considered keeping a thin compatibility shim that translates old kinds to new ones, but the SDK 0.3.0 typings make the old kinds a hard type error. A clean rename is simpler and the bridge has not shipped 0.3.0 support before, so there is no caller to maintain backward compatibility with.
- The explicit `@github/copilot` pin is intentional: the SDK only declares a transitive `^1.0.21` constraint, which means without a top-level pin `npm install` keeps drifting to whatever CLI is latest, even when that CLI is incompatible with the installed SDK. This is the underlying root cause of #201.

## Issue

Closes ChrisRomp/copilot-bridge#201
