### PR TITLE
SDK 0.3.0 follow-up: replace local ProviderConfig type, add permission vocabulary tests

### DIFF
--- a/src/core/bridge.ts
+++ b/src/core/bridge.ts
@@ -15,25 +15,19 @@ import {
   type SessionLifecycleHandler,
   type Tool,
   type TelemetryConfig,
+  type ProviderConfig,
 } from '@github/copilot-sdk';
 import type { SessionHooks } from './hooks-loader.js';
 import type { BridgeProviderConfig } from '../types.js';
+
+// Re-export SDK ProviderConfig under the old name for backward compat
+export type SDKProviderConfig = ProviderConfig;
 
 // SDK types not re-exported from package root
 type UserInputHandler = (
   request: { question: string; choices?: string[]; allowFreeform?: boolean },
   invocation: { sessionId: string },
 ) => Promise<{ answer: string; wasFreeform: boolean }> | { answer: string; wasFreeform: boolean };
-
-// SDK ProviderConfig — matches @github/copilot-sdk types.d.ts
-export interface SDKProviderConfig {
-  type?: 'openai' | 'azure' | 'anthropic';
-  wireApi?: 'completions' | 'responses';
-  baseUrl: string;
-  apiKey?: string;
-  bearerToken?: string;
-  azure?: { apiVersion?: string };
-}
 
 export class CopilotBridge {
   private client: CopilotClient;

--- a/src/core/permission-vocabulary.test.ts
+++ b/src/core/permission-vocabulary.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PendingPermission } from '../types.js';
+
+// Mock workspace-manager to avoid filesystem side effects in SessionManager constructor
+vi.mock('./workspace-manager.js', () => ({
+  getWorkspacePath: vi.fn().mockReturnValue('/tmp/test-workspace'),
+  getWorkspaceAllowPaths: vi.fn().mockResolvedValue([]),
+  ensureWorkspacesDir: vi.fn(),
+}));
+
+// Mock mcp-servers module (loadMcpServers reads filesystem)
+vi.mock('./mcp-servers.js', async () => {
+  const actual = await vi.importActual('./mcp-servers.js') as Record<string, unknown>;
+  return { ...actual };
+});
+
+// Stub loadMcpServers via session-manager internal usage (it's a module-level function)
+// We'll handle this by mocking the fs reads it depends on
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs') as Record<string, unknown>;
+  return {
+    ...actual,
+    existsSync: vi.fn((p: string) => {
+      // Let the test tempdir work, block plugin/MCP scanning
+      if (typeof p === 'string' && (p.includes('installed-plugins') || p.includes('mcp-config.json'))) {
+        return false;
+      }
+      return (actual as any).existsSync(p);
+    }),
+  };
+});
+
+import { SessionManager } from './session-manager.js';
+import { CopilotBridge } from './bridge.js';
+
+describe('permission vocabulary (hook → SDK resolution)', () => {
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    // Stub CopilotBridge minimally — we don't need real SDK calls
+    const stubBridge = {} as CopilotBridge;
+    manager = new SessionManager(stubBridge);
+  });
+
+  it('approve-once from resolvePermission maps to hook allow', async () => {
+    const channelId = 'test-chan';
+    const hooks = {
+      onPreToolUse: vi.fn().mockResolvedValue({
+        permissionDecision: 'ask',
+        permissionDecisionReason: 'Hook wants confirmation',
+      }),
+    };
+
+    // Wrap hooks through the production path
+    const wrapped = (manager as any).wrapHooksWithAsk(hooks, channelId);
+    expect(wrapped?.onPreToolUse).toBeDefined();
+
+    // Invoke the wrapped hook — it should create a pending permission and block
+    const hookPromise = wrapped!.onPreToolUse!(
+      { toolName: 'bash', toolArgs: '{"command":"ls"}', timestamp: Date.now(), cwd: '/tmp' },
+      { sessionId: 'sess-1' },
+    );
+
+    // Yield so the async hook reaches the pending-permission setup
+    await new Promise(r => setTimeout(r, 0));
+
+    // Verify a pending permission was queued
+    const queue = (manager as any).pendingPermissions.get(channelId);
+    expect(queue).toHaveLength(1);
+    expect(queue[0].fromHook).toBe(true);
+    expect(queue[0].toolName).toBe('hook:bash');
+
+    // Resolve via the production resolvePermission path (allow=true)
+    const resolved = await manager.resolvePermission(channelId, true);
+    expect(resolved).toBe(true);
+
+    // The hook promise should resolve with the mapped vocabulary
+    const result = await hookPromise;
+    expect(result.permissionDecision).toBe('allow');
+  });
+
+  it('reject from resolvePermission maps to hook deny', async () => {
+    const channelId = 'test-chan-deny';
+    const hooks = {
+      onPreToolUse: vi.fn().mockResolvedValue({
+        permissionDecision: 'ask',
+        permissionDecisionReason: 'Needs review',
+      }),
+    };
+
+    const wrapped = (manager as any).wrapHooksWithAsk(hooks, channelId);
+
+    const hookPromise = wrapped!.onPreToolUse!(
+      { toolName: 'edit', toolArgs: '{}', timestamp: Date.now(), cwd: '/tmp' },
+      { sessionId: 'sess-2' },
+    );
+
+    // Yield so the async hook reaches the pending-permission setup
+    await new Promise(r => setTimeout(r, 0));
+
+    // Resolve via production path (allow=false → reject)
+    await manager.resolvePermission(channelId, false);
+
+    const result = await hookPromise;
+    expect(result.permissionDecision).toBe('deny');
+    expect(result.permissionDecisionReason).toBe('Needs review');
+  });
+
+  it('non-ask hook decisions pass through without queuing', async () => {
+    const channelId = 'test-chan-passthrough';
+    const hooks = {
+      onPreToolUse: vi.fn().mockResolvedValue({
+        permissionDecision: 'allow',
+        additionalContext: 'auto-approved',
+      }),
+    };
+
+    const wrapped = (manager as any).wrapHooksWithAsk(hooks, channelId);
+
+    const result = await wrapped!.onPreToolUse!(
+      { toolName: 'bash', toolArgs: '{}', timestamp: Date.now(), cwd: '/tmp' },
+      { sessionId: 'sess-3' },
+    );
+
+    // Should pass through directly — no pending permission created
+    expect(result.permissionDecision).toBe('allow');
+    expect(result.additionalContext).toBe('auto-approved');
+    expect((manager as any).pendingPermissions.get(channelId)).toBeUndefined();
+  });
+
+  it('null hook result passes through without queuing', async () => {
+    const channelId = 'test-chan-null';
+    const hooks = {
+      onPreToolUse: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const wrapped = (manager as any).wrapHooksWithAsk(hooks, channelId);
+
+    const result = await wrapped!.onPreToolUse!(
+      { toolName: 'bash', toolArgs: '{}', timestamp: Date.now(), cwd: '/tmp' },
+      { sessionId: 'sess-4' },
+    );
+
+    expect(result).toBeUndefined();
+    expect((manager as any).pendingPermissions.get(channelId)).toBeUndefined();
+  });
+
+  it('hooks without onPreToolUse are returned unchanged', () => {
+    const hooks = { onSessionStart: vi.fn() };
+    const wrapped = (manager as any).wrapHooksWithAsk(hooks, 'chan');
+    expect(wrapped).toBe(hooks);
+  });
+
+  it('undefined hooks return undefined', () => {
+    const wrapped = (manager as any).wrapHooksWithAsk(undefined, 'chan');
+    expect(wrapped).toBeUndefined();
+  });
+
+  it('resolvePermission returns false when no pending permissions', async () => {
+    const result = await manager.resolvePermission('nonexistent', true);
+    expect(result).toBe(false);
+  });
+});
+
+describe('PendingPermission resolve type contract', () => {
+  it('resolve callback accepts SDK 0.3.0 vocabulary', () => {
+    // Verify the PendingPermission type accepts the new vocabulary at compile time.
+    // This test is a compile-time guard — if the type regresses, tsc will fail.
+    const results: Parameters<PendingPermission['resolve']>[0][] = [
+      { kind: 'approve-once' },
+      { kind: 'reject' },
+      { kind: 'reject', feedback: 'not allowed' },
+      { kind: 'user-not-available' },
+    ];
+    expect(results).toHaveLength(4);
+  });
+});

--- a/src/core/permission-vocabulary.test.ts
+++ b/src/core/permission-vocabulary.test.ts
@@ -8,14 +8,7 @@ vi.mock('./workspace-manager.js', () => ({
   ensureWorkspacesDir: vi.fn(),
 }));
 
-// Mock mcp-servers module (loadMcpServers reads filesystem)
-vi.mock('./mcp-servers.js', async () => {
-  const actual = await vi.importActual('./mcp-servers.js') as Record<string, unknown>;
-  return { ...actual };
-});
-
-// Stub loadMcpServers via session-manager internal usage (it's a module-level function)
-// We'll handle this by mocking the fs reads it depends on
+// Block filesystem scanning in loadMcpServers (internal to session-manager.ts)
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual('node:fs') as Record<string, unknown>;
   return {
@@ -128,7 +121,7 @@ describe('permission vocabulary (hook → SDK resolution)', () => {
     expect((manager as any).pendingPermissions.get(channelId)).toBeUndefined();
   });
 
-  it('null hook result passes through without queuing', async () => {
+  it('undefined hook result passes through without queuing', async () => {
     const channelId = 'test-chan-null';
     const hooks = {
       onPreToolUse: vi.fn().mockResolvedValue(undefined),
@@ -164,8 +157,8 @@ describe('permission vocabulary (hook → SDK resolution)', () => {
 
 describe('PendingPermission resolve type contract', () => {
   it('resolve callback accepts SDK 0.3.0 vocabulary', () => {
-    // Verify the PendingPermission type accepts the new vocabulary at compile time.
-    // This test is a compile-time guard — if the type regresses, tsc will fail.
+    // Documents the expected vocabulary as a runtime assertion.
+    // Note: tsconfig excludes test files, so this isn't a tsc-level guard.
     const results: Parameters<PendingPermission['resolve']>[0][] = [
       { kind: 'approve-once' },
       { kind: 'reject' },


### PR DESCRIPTION
## Summary
Follow-up to [#202](https://github.com/ChrisRomp/copilot-bridge/pull/202) (SDK 0.3.0 compatibility). Replaces a redundant local type with the SDK export and adds test coverage for the previously untested hook permission resolution path.

### What it does
- Imports `ProviderConfig` from `@github/copilot-sdk` instead of maintaining a local copy
- Re-exports as `SDKProviderConfig` type alias for backward compatibility
- Adds 8 tests covering the hook `ask` decision -> pending permission -> `resolvePermission()` -> SDK vocabulary mapping

### Key changes
- `src/core/bridge.ts`: Replaced local `SDKProviderConfig` interface with SDK `ProviderConfig` import + type alias
- `src/core/permission-vocabulary.test.ts`: New test file exercising the production `wrapHooksWithAsk()` and `resolvePermission()` code paths

### Testing
- All 699 tests pass (8 new + 691 existing)
- `npm run build` passes (validates the type alias works across module boundaries)