### PR TITLE
fix: update /model billing display for token-based pricing

### DIFF
--- a/src/core/byok-model-ux.test.ts
+++ b/src/core/byok-model-ux.test.ts
@@ -10,6 +10,12 @@ const copilotModels: ModelInfo[] = [
   { id: 'claude-opus-4.6', name: 'Claude Opus 4.6', billing: { multiplier: 2 }, supportedReasoningEfforts: ['low', 'medium', 'high'] },
 ];
 
+const copilotModelsTokenBilling: ModelInfo[] = [
+  { id: 'claude-sonnet-4.6', name: 'Claude Sonnet 4.6', billing: { token_prices: { batch_size: 1000000, cache_price: 30000000000, input_price: 300000000000, output_price: 1500000000000 } } },
+  { id: 'gpt-5.4', name: 'GPT-5.4', billing: { token_prices: { batch_size: 1000000, cache_price: 17500000000, input_price: 175000000000, output_price: 1400000000000 }, restricted_to: ['pro', 'pro_plus'] } },
+  { id: 'claude-opus-4.6', name: 'Claude Opus 4.6', billing: { token_prices: { batch_size: 1000000, cache_price: 50000000000, input_price: 500000000000, output_price: 2500000000000 } }, supportedReasoningEfforts: ['low', 'medium', 'high'] },
+];
+
 const byokModels: ModelInfo[] = [
   { id: 'ollama-local:qwen3:8b', name: 'Qwen 3 8B' },
   { id: 'ollama-local:qwen3:14b', name: 'Qwen 3 14B' },
@@ -145,7 +151,7 @@ describe('/model command listing', () => {
 
   it('shows current model indicator for Copilot model', async () => {
     const result = await handleCommand(channelId, '/model', sessionInfo, prefs, meta, allModels, undefined, null, providers);
-    expect(result.response).toContain('← current');
+    expect(result.response).toContain('<- current');
   });
 
   it('filters by provider name', async () => {
@@ -157,17 +163,19 @@ describe('/model command listing', () => {
 
   it('hides Billing column for BYOK provider sections', async () => {
     const result = await handleCommand(channelId, '/model', sessionInfo, prefs, meta, allModels, undefined, null, providers);
-    // Copilot section should have Billing in table header
+    // Copilot section should have Billing-related columns
     const sections = result.response!.split('**ollama-local**');
-    expect(sections[0]).toContain('| Model | Billing |');
-    // BYOK section table header should NOT have Billing
+    expect(sections[0]).toMatch(/\| Model \| (Billing|Input) \|/);
+    // BYOK section table header should NOT have Billing/pricing
     const byokTable = sections[1].split('🧠')[0]; // before the legend
     expect(byokTable).not.toContain('Billing');
+    expect(byokTable).not.toContain('Input');
   });
 
   it('hides Billing column when filtering to BYOK provider', async () => {
     const result = await handleCommand(channelId, '/model ollama-local', sessionInfo, prefs, meta, allModels, undefined, null, providers);
     expect(result.response).not.toContain('Billing');
+    expect(result.response).not.toContain('Input');
   });
 
   it('shows no-provider listing without providers', async () => {
@@ -175,6 +183,40 @@ describe('/model command listing', () => {
     expect(result.handled).toBe(true);
     expect(result.response).not.toContain('GitHub Copilot'); // no grouping without providers
     expect(result.response).toContain('claude-sonnet-4.6');
+  });
+
+  it('shows token-based pricing columns when API returns token_prices', async () => {
+    const result = await handleCommand(channelId, '/model', sessionInfo, prefs, meta, copilotModelsTokenBilling);
+    // Should have Input/Cached input/Output column headers
+    expect(result.response).toContain('| Input |');
+    expect(result.response).toContain('| Cached input |');
+    expect(result.response).toContain('| Output |');
+    // Verify actual prices match GitHub docs
+    expect(result.response).toContain('$3.00');    // sonnet input
+    expect(result.response).toContain('$0.30');    // sonnet cached (sub-dollar precision)
+    expect(result.response).toContain('$15.00');   // sonnet output
+    expect(result.response).toContain('$1.75');    // gpt-5.4 input
+    expect(result.response).toContain('$0.175');   // gpt-5.4 cached (3 decimal places)
+    expect(result.response).toContain('$/M tokens');
+    // Anthropic note and docs link (claude models present)
+    expect(result.response).toContain('cache write');
+    expect(result.response).toContain('models-and-pricing');
+  });
+
+  it('shows multiplier billing when API returns multiplier', async () => {
+    const result = await handleCommand(channelId, '/model', sessionInfo, prefs, meta, copilotModels);
+    expect(result.response).toContain('1x');
+    expect(result.response).toContain('2x');
+    expect(result.response).toContain('premium request multiplier');
+  });
+
+  it('hides Anthropic cache write note when no Claude models present', async () => {
+    const openaiOnly: ModelInfo[] = [
+      { id: 'gpt-5.4', name: 'GPT-5.4', billing: { token_prices: { batch_size: 1000000, cache_price: 17500000000, input_price: 175000000000, output_price: 1400000000000 } } },
+    ];
+    const result = await handleCommand(channelId, '/model', sessionInfo, prefs, meta, openaiOnly);
+    expect(result.response).not.toContain('cache write');
+    expect(result.response).toContain('models-and-pricing'); // docs link still present
   });
 });
 

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -33,7 +33,11 @@ async function isStreamerMode(): Promise<boolean> {
 export interface ModelInfo {
   id: string;
   name: string;
-  billing?: { multiplier: number };
+  billing?: {
+    multiplier?: number;
+    token_prices?: { batch_size: number; input_price: number; output_price: number; cache_price?: number };
+    restricted_to?: string[];
+  };
   supportedReasoningEfforts?: string[];
   defaultReasoningEffort?: string;
 }
@@ -182,19 +186,54 @@ async function formatModelListing(models: ModelInfo[], providerNames: string[], 
     return m.id === currentModel;
   };
 
-  const formatRow = (m: ModelInfo, showBilling: boolean): string => {
-    const current = isCurrent(m) ? ' ← current' : '';
+  // API prices are in AI credit sub-units per batch_size tokens.
+  // 1 AI credit = $0.01; dividing by 1e5 converts to dollars per 1M tokens.
+  // See https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
+  const AI_CREDIT_SCALE = 1e5;
+
+  const formatPrice = (price: number, batchSize: number): string => {
+    const perMillion = price / batchSize / AI_CREDIT_SCALE;
+    if (perMillion < 0.01) return `$${perMillion.toPrecision(2)}`;
+    if (perMillion < 1) {
+      // Show enough precision: $0.30, $0.175, $0.025
+      const threeDecimals = perMillion.toFixed(3);
+      return threeDecimals.endsWith('0') ? `$${perMillion.toFixed(2)}` : `$${threeDecimals}`;
+    }
+    return `$${perMillion.toFixed(2)}`;
+  };
+
+  // Detect billing format from all Copilot models
+  const copilotModelsList = models.filter(m => !providerNames.some(p => m.id.startsWith(`${p}:`)));
+  const useTokenPricing = copilotModelsList.some(m => m.billing?.token_prices !== undefined);
+  const useMultiplier = !useTokenPricing && copilotModelsList.some(m => m.billing?.multiplier !== undefined);
+
+  const formatRow = (m: ModelInfo, billingMode: 'none' | 'multiplier' | 'tokens'): string => {
+    const current = isCurrent(m) ? ' <- current' : '';
     const reasoning = m.supportedReasoningEfforts?.length ? ' 🧠' : '';
     const hidden = streamer && isHiddenModel(m);
     const displayName = hidden ? redactedModelLabel(++hiddenIndex) : `\`${m.id}\``;
-    if (showBilling) {
-      const billing = m.billing ? `${m.billing.multiplier}x` : '—';
+    if (billingMode === 'tokens' && m.billing?.token_prices) {
+      const tp = m.billing.token_prices;
+      const input = formatPrice(tp.input_price, tp.batch_size);
+      const cached = tp.cache_price !== undefined ? formatPrice(tp.cache_price, tp.batch_size) : '--';
+      const output = formatPrice(tp.output_price, tp.batch_size);
+      return `| ${displayName} | ${input} | ${cached} | ${output} |${reasoning}${current} |`;
+    }
+    if (billingMode === 'tokens') {
+      // token pricing mode but this model has no token_prices
+      return `| ${displayName} | -- | -- | -- |${reasoning}${current} |`;
+    }
+    if (billingMode === 'multiplier') {
+      const billing = m.billing?.multiplier !== undefined ? `${m.billing.multiplier}x` : '--';
       return `| ${displayName} | ${billing} |${reasoning}${current} |`;
     }
     return `| ${displayName} |${reasoning}${current} |`;
   };
 
-  const copilotHeader = '| Model | Billing | |\n|:------|--------:|:--|';
+  const billingMode = useTokenPricing ? 'tokens' as const : useMultiplier ? 'multiplier' as const : 'none' as const;
+  const copilotHeader = useTokenPricing
+    ? '| Model | Input | Cached input | Output | |\n|:------|------:|-------------:|-------:|:--|'
+    : '| Model | Billing | |\n|:------|--------:|:--|';
   const byokHeader = '| Model | |\n|:------|:--|';
 
   const title = filterProvider ? `**Models: ${filterProvider}**` : '**Available Models**';
@@ -202,37 +241,51 @@ async function formatModelListing(models: ModelInfo[], providerNames: string[], 
 
   if (providerNames.length > 0 && !filterProvider) {
     // Group by provider: Copilot first, then each BYOK provider
-    const copilotModels = models.filter(m => !providerNames.some(p => m.id.startsWith(`${p}:`)));
+    const copilotModels = copilotModelsList;
     if (copilotModels.length > 0) {
       lines.push('**GitHub Copilot**', '', copilotHeader);
-      for (const m of copilotModels) lines.push(formatRow(m, true));
+      for (const m of copilotModels) lines.push(formatRow(m, billingMode));
       lines.push('');
     }
     for (const prov of providerNames) {
       const provModels = models.filter(m => m.id.startsWith(`${prov}:`));
       if (provModels.length > 0) {
         lines.push(`**${prov}**`, '', byokHeader);
-        for (const m of provModels) lines.push(formatRow(m, false));
+        for (const m of provModels) lines.push(formatRow(m, 'none'));
         lines.push('');
       }
     }
   } else if (filterProvider) {
-    // Filtered to single BYOK provider — no billing column
+    // Filtered to single BYOK provider -- no billing column
     lines.push(byokHeader);
-    for (const m of models) lines.push(formatRow(m, false));
+    for (const m of models) lines.push(formatRow(m, 'none'));
     lines.push('');
   } else {
     // Flat listing (no providers configured)
     lines.push(copilotHeader);
-    for (const m of models) lines.push(formatRow(m, true));
+    for (const m of models) lines.push(formatRow(m, billingMode));
     lines.push('');
   }
 
-  const hasCopilotModels = !filterProvider && models.some(m => !providerNames.some(p => m.id.startsWith(`${p}:`)));
-  const legend = hasCopilotModels
-    ? '🧠 = supports reasoning effort · Billing = premium request multiplier'
-    : '🧠 = supports reasoning effort';
-  lines.push(legend);
+  const hasCopilotModels = !filterProvider && copilotModelsList.length > 0;
+  let legend = '🧠 = supports reasoning effort';
+  if (hasCopilotModels) {
+    if (useTokenPricing) {
+      legend += ' -- prices are $/M tokens';
+      lines.push(legend);
+      if (copilotModelsList.some(m => m.id.startsWith('claude-'))) {
+        lines.push('Anthropic models also incur cache write costs not shown above.');
+      }
+      lines.push('[Full pricing details](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing)');
+    } else if (useMultiplier) {
+      legend += ' -- Billing = premium request multiplier';
+      lines.push(legend);
+    } else {
+      lines.push(legend);
+    }
+  } else {
+    lines.push(legend);
+  }
   lines.push('↳ Use `/model <name>` to switch');
   if (providerNames.length > 0 && !filterProvider) {
     const shown = providerNames.slice(0, 3).join(', ');

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -192,6 +192,7 @@ async function formatModelListing(models: ModelInfo[], providerNames: string[], 
   const AI_CREDIT_SCALE = 1e5;
 
   const formatPrice = (price: number, batchSize: number): string => {
+    if (!Number.isFinite(price) || !batchSize) return '--';
     const perMillion = price / batchSize / AI_CREDIT_SCALE;
     if (perMillion < 0.01) return `$${perMillion.toPrecision(2)}`;
     if (perMillion < 1) {


### PR DESCRIPTION
## Summary

The Copilot API now returns `token_prices` (per-token pricing in AI credits) instead of the legacy `multiplier` (premium request multiplier) for accounts on usage-based billing. The old code produced `undefinedx` in the Billing column.

### What it does
- Detects billing format at runtime -- handles both multiplier and token-pricing accounts
- Token mode shows Input, Cached input, Output columns with $/M token prices
- Multiplier mode continues showing the single Billing column unchanged
- Prices verified against [GitHub's pricing docs](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing)
- Anthropic cache write note shown only when Claude models are present
- Guards against malformed API data (zero batch_size, non-finite values)

### Key changes
- `src/core/command-handler.ts`: `ModelInfo.billing` type widened, `formatPrice()` + `formatRow()` rewritten, format detection, legend/notes
- `src/core/byok-model-ux.test.ts`: 3 new tests (token pricing, multiplier, Anthropic note gating), updated existing tests

### Notes
- SDK types (even 1.0.0-beta.3) still define `ModelBilling` as `{ multiplier: number }` -- the API is ahead of the SDK
- The API does not return a `cache_write_price` field for Anthropic models; a note directs users to the pricing docs