### PR TITLE
fix(hooks): pass cwd to CopilotClient - default to os.homedir()

### DIFF
--- a/src/core/bridge.test.ts
+++ b/src/core/bridge.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import os from 'node:os';
+
+// Mock @github/copilot-sdk before importing bridge
+vi.mock('@github/copilot-sdk', () => {
+  const mockClient = {
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn().mockReturnValue(() => {}),
+    createSession: vi.fn().mockResolvedValue({ sessionId: 'test-session', disconnect: vi.fn() }),
+  };
+  const MockCopilotClient = vi.fn(function MockCopilotClient() {
+    return mockClient;
+  });
+  return { CopilotClient: MockCopilotClient };
+});
+
+import { CopilotBridge } from './bridge.js';
+import { CopilotClient } from '@github/copilot-sdk';
+
+describe('CopilotBridge constructor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes os.homedir() as cwd to CopilotClient when no cwd option given', () => {
+    new CopilotBridge();
+    expect(CopilotClient).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: os.homedir() })
+    );
+  });
+
+  it('passes explicit cwd to CopilotClient when cwd option given', () => {
+    new CopilotBridge({ cwd: '/custom/path' });
+    expect(CopilotClient).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/custom/path' })
+    );
+  });
+
+  it('still passes telemetry and env when provided alongside cwd', () => {
+    const env = { FOO: 'bar' };
+    new CopilotBridge({ env, cwd: '/some/dir' });
+    expect(CopilotClient).toHaveBeenCalledWith(
+      expect.objectContaining({ env, cwd: '/some/dir' })
+    );
+  });
+});

--- a/src/core/bridge.ts
+++ b/src/core/bridge.ts
@@ -17,6 +17,7 @@ import {
   type TelemetryConfig,
   type ProviderConfig,
 } from '@github/copilot-sdk';
+import os from 'node:os';
 import type { SessionHooks } from './hooks-loader.js';
 import type { BridgeProviderConfig } from '../types.js';
 
@@ -37,9 +38,10 @@ export class CopilotBridge {
 
   onLifecycleEvent?: SessionLifecycleHandler;
 
-  constructor(options?: { telemetry?: TelemetryConfig; env?: NodeJS.ProcessEnv }) {
+  constructor(options?: { telemetry?: TelemetryConfig; env?: NodeJS.ProcessEnv; cwd?: string }) {
     this.client = new CopilotClient({
       autoStart: true,
+      cwd: options?.cwd ?? os.homedir(),
       telemetry: options?.telemetry,
       env: options?.env,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -449,7 +449,9 @@ async function main(): Promise<void> {
 
   // Initialize Copilot SDK bridge
   const { telemetry: sdkTelemetry, env: telemetryEnv } = resolveTelemetryConfig(config);
-  const bridge = new CopilotBridge(sdkTelemetry || telemetryEnv ? { telemetry: sdkTelemetry, env: telemetryEnv } : undefined);
+  const bridge = new CopilotBridge(sdkTelemetry || telemetryEnv
+  ? { telemetry: sdkTelemetry, env: telemetryEnv, cwd: os.homedir() }
+  : { cwd: os.homedir() });
   await bridge.start();
   log.info('Copilot SDK connected');
 


### PR DESCRIPTION
## Summary

`CopilotBridge` constructed `CopilotClient` with no `cwd` option, so the CLI subprocess was always spawned from `process.cwd()` (wherever the bridge process was launched). `sessionStart`, `sessionEnd`, and `errorOccurred` hooks are fired by the CLI subprocess via `hooks.invoke` RPC - the subprocess resolved hook scripts relative to its spawn CWD, silently ignoring workspace-scoped hooks in any `workingDirectory` that differed from the bridge launch directory.

`preToolUse`, `postToolUse`, and `userPromptSubmitted` were not affected - the bridge loads and executes those hook scripts directly in Node from the correct `workingDirectory`.

Fixes: #233

## Changes

**`src/core/bridge.ts`**
- Added `cwd?: string` to `CopilotBridge` constructor options
- Passes `cwd: options?.cwd ?? os.homedir()` to `CopilotClient`
- Default is `os.homedir()` - stable and predictable regardless of how the bridge was launched

**`src/index.ts`**
- Updated `new CopilotBridge(...)` to pass `{ cwd: os.homedir() }`

**`src/core/bridge.test.ts`** (new)
- 3 tests verifying `cwd` is passed correctly to `CopilotClient` in all constructor permutations

## Validation

- `npx tsc --noEmit`: clean
- `npx vitest run`: 745 passed (37 files) - 742 baseline + 3 new
